### PR TITLE
feat: eks support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/efs v1.1.1
+	github.com/aws/aws-sdk-go-v2/service/eks v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/emr v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.1.1 h1:McBGvH3M7n8s6SGuS+UNm8+q5BEmE
 github.com/aws/aws-sdk-go-v2/service/ecs v1.1.1/go.mod h1:HHh+ZaGFQVK16XijQFZKaJdTpeOdxWK894pn9vY2Tgo=
 github.com/aws/aws-sdk-go-v2/service/efs v1.1.1 h1:UnjpU4x5bCWhJn43C+FXSjRs4fh8z8YjN8AsjxkEFW8=
 github.com/aws/aws-sdk-go-v2/service/efs v1.1.1/go.mod h1:fJbRgAwIrq3LyqphCXgJs6bVYfMlLZ9G6vepkPvAJsw=
+github.com/aws/aws-sdk-go-v2/service/eks v1.1.1 h1:nK/Kl0TIfwaHUkcCj9+L6td2Xds7QNYMODJKWG1wPOY=
+github.com/aws/aws-sdk-go-v2/service/eks v1.1.1/go.mod h1:9SVAH9Cu/e1iQOu7VIBp7DhqTq3Dr5cAooCzoh61mEc=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.1.1 h1:xLqpXaLCUtHJuJiOASwPIPLAJMt1v+6h8phzma1haT8=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.1.1/go.mod h1:9Klmao5OCdCMYyXPNy+skSx6c4LoKsbPL8IcEqV5wVU=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.1.1 h1:ARoh9oSYV0QwcenklgpagsW+fI0xx5STB31yn3BtcPE=

--- a/provider/config.go
+++ b/provider/config.go
@@ -30,6 +30,7 @@ const configYaml = `
       - name: ecs.clusters
       - name: ecr.images
       - name: efs.filesystems
+      - name: eks.clusters
       - name: elasticbeanstalk.environments
       - name: elbv2.load_balancers
       - name: elbv2.target_groups

--- a/resources/eks/client.go
+++ b/resources/eks/client.go
@@ -1,10 +1,10 @@
-package ecs
+package eks
 
 import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/cloudquery/cloudquery/database"
 	"github.com/cloudquery/cq-provider-aws/resources/resource"
 	"github.com/hashicorp/go-hclog"
@@ -15,17 +15,16 @@ type Client struct {
 	log       hclog.Logger
 	accountID string
 	region    string
-	svc       *ecs.Client
+	svc       *eks.Client
 }
 
-func NewClient(awsConfig aws.Config, db *database.Database, log hclog.Logger,
-	accountID string, region string) resource.ClientInterface {
+func NewClient(awsConfig aws.Config, db *database.Database, log hclog.Logger, accountID string, region string) resource.ClientInterface {
 	return &Client{
 		db:        db,
 		log:       log,
 		accountID: accountID,
 		region:    region,
-		svc: ecs.NewFromConfig(awsConfig, func(options *ecs.Options) {
+		svc: eks.NewFromConfig(awsConfig, func(options *eks.Options) {
 			options.Region = region
 		}),
 	}
@@ -36,6 +35,6 @@ func (c *Client) CollectResource(resource string, config interface{}) error {
 	case "clusters":
 		return c.clusters(config)
 	default:
-		return fmt.Errorf("unsupported resource ecs.%s", resource)
+		return fmt.Errorf("unsupported resource eks.%s", resource)
 	}
 }

--- a/resources/eks/clusters.go
+++ b/resources/eks/clusters.go
@@ -175,32 +175,38 @@ func (c *Client) transformEKSClusters(values *[]types.Cluster) []*Cluster {
 	var tValues []*Cluster
 	for _, value := range *values {
 		tValue := Cluster{
-			AccountID:                c.accountID,
-			Region:                   c.region,
-			Name:                     value.Name,
-			Arn:                      value.Arn,
-			CertificateAuthorityData: value.CertificateAuthority.Data,
-			CreatedAt:                value.CreatedAt,
-			Endpoint:                 value.Endpoint,
-			PlatformVersion:          value.PlatformVersion,
-			VpcID:                    value.ResourcesVpcConfig.VpcId,
-			SecurityGroupID:          value.ResourcesVpcConfig.ClusterSecurityGroupId,
-			EndpointPrivateAccess:    value.ResourcesVpcConfig.EndpointPrivateAccess,
-			EndpointPublicAccess:     value.ResourcesVpcConfig.EndpointPublicAccess,
-			RoleArn:                  value.RoleArn,
-			Status:                   string(value.Status),
-			Version:                  value.Version,
-			Tags:                     c.transformClusterTags(&value.Tags),
-			LoggingConfigurations:    c.transformClusterLoggingConfigurations(&value.Logging.ClusterLogging),
-			PublicAccessCidrs:        c.transformClusterPublicAccessCidrs(&value.ResourcesVpcConfig.PublicAccessCidrs),
-			SecurityGroups:           c.transformClusterSecurityGroups(&value.ResourcesVpcConfig.SecurityGroupIds),
-			Subnets:                  c.transformClusterSubnets(&value.ResourcesVpcConfig.SubnetIds),
+			AccountID:       c.accountID,
+			Region:          c.region,
+			Name:            value.Name,
+			Arn:             value.Arn,
+			CreatedAt:       value.CreatedAt,
+			Endpoint:        value.Endpoint,
+			PlatformVersion: value.PlatformVersion,
+			RoleArn:         value.RoleArn,
+			Status:          string(value.Status),
+			Version:         value.Version,
+			Tags:            c.transformClusterTags(&value.Tags),
+		}
+		if value.CertificateAuthority != nil {
+			tValue.CertificateAuthorityData = value.CertificateAuthority.Data
 		}
 		if value.Identity != nil && value.Identity.Oidc != nil {
 			tValue.OidcIssuer = value.Identity.Oidc.Issuer
 		}
 		if value.KubernetesNetworkConfig != nil {
 			tValue.ServiceIpv4Cidr = value.KubernetesNetworkConfig.ServiceIpv4Cidr
+		}
+		if value.Logging != nil && value.Logging.ClusterLogging != nil {
+			tValue.LoggingConfigurations = c.transformClusterLoggingConfigurations(&value.Logging.ClusterLogging)
+		}
+		if value.ResourcesVpcConfig != nil {
+			tValue.PublicAccessCidrs = c.transformClusterPublicAccessCidrs(&value.ResourcesVpcConfig.PublicAccessCidrs)
+			tValue.SecurityGroups = c.transformClusterSecurityGroups(&value.ResourcesVpcConfig.SecurityGroupIds)
+			tValue.Subnets = c.transformClusterSubnets(&value.ResourcesVpcConfig.SubnetIds)
+			tValue.VpcID = value.ResourcesVpcConfig.VpcId
+			tValue.SecurityGroupID = value.ResourcesVpcConfig.ClusterSecurityGroupId
+			tValue.EndpointPrivateAccess = value.ResourcesVpcConfig.EndpointPrivateAccess
+			tValue.EndpointPublicAccess = value.ResourcesVpcConfig.EndpointPublicAccess
 		}
 		tValues = append(tValues, &tValue)
 	}

--- a/resources/eks/clusters.go
+++ b/resources/eks/clusters.go
@@ -1,0 +1,252 @@
+package eks
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/mitchellh/mapstructure"
+)
+
+type Cluster struct {
+	ID                       uint `gorm:"primarykey"`
+	AccountID                string
+	Region                   string
+	Name                     *string
+	Arn                      *string
+	CertificateAuthorityData *string
+	CreatedAt                *time.Time
+	Endpoint                 *string
+	OidcIssuer               *string
+	ServiceIpv4Cidr          *string
+	PlatformVersion          *string
+	VpcID                    *string
+	SecurityGroupID          *string
+	EndpointPrivateAccess    bool
+	EndpointPublicAccess     bool
+	RoleArn                  *string
+	Status                   string
+	Version                  *string
+	Tags                     []*ClusterTag                  `gorm:"constraint:OnDelete:CASCADE;"`
+	LoggingConfigurations    []*ClusterLoggingConfiguration `gorm:"constraint:OnDelete:CASCADE;"`
+	PublicAccessCidrs        []*ClusterPublicAccessCidr     `gorm:"constraint:OnDelete:CASCADE;"`
+	SecurityGroups           []*ClusterSecurityGroup        `gorm:"constraint:OnDelete:CASCADE;"`
+	Subnets                  []*ClusterSubnet               `gorm:"constraint:OnDelete:CASCADE;"`
+}
+
+func (Cluster) TableName() string {
+	return "aws_eks_clusters"
+}
+
+type ClusterTag struct {
+	ID        uint   `gorm:"primarykey"`
+	ClusterID uint   `neo:"ignore"`
+	AccountID string `gorm:"-"`
+	Region    string `gorm:"-"`
+
+	Key   *string
+	Value *string
+}
+
+func (ClusterTag) TableName() string {
+	return "aws_eks_cluster_tags"
+}
+
+type ClusterLoggingConfiguration struct {
+	ID        uint   `gorm:"primarykey"`
+	ClusterID uint   `neo:"ignore"`
+	AccountID string `gorm:"-"`
+	Region    string `gorm:"-"`
+
+	Enabled *bool
+	Type    string
+}
+
+func (ClusterLoggingConfiguration) TableName() string {
+	return "aws_eks_logging_configurations"
+}
+
+type ClusterPublicAccessCidr struct {
+	ID        uint   `gorm:"primarykey"`
+	ClusterID uint   `neo:"ignore"`
+	AccountID string `gorm:"-"`
+	Region    string `gorm:"-"`
+
+	Cidr string
+}
+
+func (ClusterPublicAccessCidr) TableName() string {
+	return "aws_eks_public_access_cidr"
+}
+
+type ClusterSecurityGroup struct {
+	ID        uint   `gorm:"primarykey"`
+	ClusterID uint   `neo:"ignore"`
+	AccountID string `gorm:"-"`
+	Region    string `gorm:"-"`
+
+	SecurityGroupID string
+}
+
+func (ClusterSecurityGroup) TableName() string {
+	return "aws_eks_security_groups"
+}
+
+type ClusterSubnet struct {
+	ID        uint   `gorm:"primarykey"`
+	ClusterID uint   `neo:"ignore"`
+	AccountID string `gorm:"-"`
+	Region    string `gorm:"-"`
+
+	SubnetID string
+}
+
+func (ClusterSubnet) TableName() string {
+	return "aws_eks_subnets"
+}
+
+func (c *Client) transformClusterTags(values *map[string]string) []*ClusterTag {
+	var tValues []*ClusterTag
+	for key, value := range *values {
+		tValues = append(tValues, &ClusterTag{
+			AccountID: c.accountID,
+			Region:    c.region,
+			Key:       &key,
+			Value:     &value,
+		})
+	}
+	return tValues
+}
+
+func (c *Client) transformClusterLoggingConfigurations(values *[]types.LogSetup) []*ClusterLoggingConfiguration {
+	var tValues []*ClusterLoggingConfiguration
+	for _, value := range *values {
+		for _, logType := range value.Types {
+			tValue := ClusterLoggingConfiguration{
+				AccountID: c.accountID,
+				Region:    c.region,
+				Enabled:   value.Enabled,
+				Type:      string(logType),
+			}
+			tValues = append(tValues, &tValue)
+		}
+	}
+	return tValues
+}
+
+func (c *Client) transformClusterPublicAccessCidrs(values *[]string) []*ClusterPublicAccessCidr {
+	var tValues []*ClusterPublicAccessCidr
+	for _, value := range *values {
+		tValues = append(tValues, &ClusterPublicAccessCidr{
+			AccountID: c.accountID,
+			Region:    c.region,
+			Cidr:      value,
+		})
+	}
+	return tValues
+}
+
+func (c *Client) transformClusterSecurityGroups(values *[]string) []*ClusterSecurityGroup {
+	var tValues []*ClusterSecurityGroup
+	for _, value := range *values {
+		tValues = append(tValues, &ClusterSecurityGroup{
+			AccountID:       c.accountID,
+			Region:          c.region,
+			SecurityGroupID: value,
+		})
+	}
+	return tValues
+}
+
+func (c *Client) transformClusterSubnets(values *[]string) []*ClusterSubnet {
+	var tValues []*ClusterSubnet
+	for _, value := range *values {
+		tValues = append(tValues, &ClusterSubnet{
+			AccountID: c.accountID,
+			Region:    c.region,
+			SubnetID:  value,
+		})
+	}
+	return tValues
+}
+
+func (c *Client) transformEKSClusters(values *[]types.Cluster) []*Cluster {
+	var tValues []*Cluster
+	for _, value := range *values {
+		tValue := Cluster{
+			AccountID:                c.accountID,
+			Region:                   c.region,
+			Name:                     value.Name,
+			Arn:                      value.Arn,
+			CertificateAuthorityData: value.CertificateAuthority.Data,
+			CreatedAt:                value.CreatedAt,
+			Endpoint:                 value.Endpoint,
+			PlatformVersion:          value.PlatformVersion,
+			VpcID:                    value.ResourcesVpcConfig.VpcId,
+			SecurityGroupID:          value.ResourcesVpcConfig.ClusterSecurityGroupId,
+			EndpointPrivateAccess:    value.ResourcesVpcConfig.EndpointPrivateAccess,
+			EndpointPublicAccess:     value.ResourcesVpcConfig.EndpointPublicAccess,
+			RoleArn:                  value.RoleArn,
+			Status:                   string(value.Status),
+			Version:                  value.Version,
+			Tags:                     c.transformClusterTags(&value.Tags),
+			LoggingConfigurations:    c.transformClusterLoggingConfigurations(&value.Logging.ClusterLogging),
+			PublicAccessCidrs:        c.transformClusterPublicAccessCidrs(&value.ResourcesVpcConfig.PublicAccessCidrs),
+			SecurityGroups:           c.transformClusterSecurityGroups(&value.ResourcesVpcConfig.SecurityGroupIds),
+			Subnets:                  c.transformClusterSubnets(&value.ResourcesVpcConfig.SubnetIds),
+		}
+		if value.Identity != nil && value.Identity.Oidc != nil {
+			tValue.OidcIssuer = value.Identity.Oidc.Issuer
+		}
+		if value.KubernetesNetworkConfig != nil {
+			tValue.ServiceIpv4Cidr = value.KubernetesNetworkConfig.ServiceIpv4Cidr
+		}
+		tValues = append(tValues, &tValue)
+	}
+	return tValues
+}
+
+var ClusterTables = []interface{}{
+	&Cluster{},
+	&ClusterTag{},
+	&ClusterLoggingConfiguration{},
+	&ClusterPublicAccessCidr{},
+	&ClusterSecurityGroup{},
+	&ClusterSubnet{},
+}
+
+func (c *Client) clusters(gConfig interface{}) error {
+	ctx := context.Background()
+	var config eks.ListClustersInput
+	err := mapstructure.Decode(gConfig, &config)
+	if err != nil {
+		return err
+	}
+	c.db.Where("region", c.region).Where("account_id", c.accountID).Delete(ClusterTables...)
+	for {
+		var clusters []types.Cluster
+		listClustersOutput, err := c.svc.ListClusters(ctx, &config)
+		if err != nil {
+			return err
+		}
+		for _, name := range listClustersOutput.Clusters {
+			describeClusterOutput, err := c.svc.DescribeCluster(ctx, &eks.DescribeClusterInput{
+				Name: &name,
+			})
+			if err != nil {
+				return err
+			}
+			clusters = append(clusters, *describeClusterOutput.Cluster)
+		}
+
+		c.db.ChunkedCreate(c.transformEKSClusters(&clusters))
+		c.log.Info("Fetched resources", "resource", "eks.clusters", "count", len(clusters))
+
+		if listClustersOutput.NextToken == nil {
+			break
+		}
+		config.NextToken = listClustersOutput.NextToken
+	}
+	return nil
+}


### PR DESCRIPTION
Adds support for ingesting EKS cluster information. I believe all fields should be captured.

There is no way to run a describe on multiple clusters at once, so I went with the approach to list clusters and describe one by one.