### PR TITLE
feat: directconnect.virtual_interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ cq-provider-aws
 *.tfstate
 *.tfstate.*
 .swp
+
+__debug_bin

--- a/adding_a_new_resource.md
+++ b/adding_a_new_resource.md
@@ -21,11 +21,12 @@ If the service to which the resource belongs has not been used before in cq-prov
 ### Skeleton
 
 1. In [client/services.go](./client/services.go), update the service interface and add the method(s) that you will be using to fetch the data from the aws sdk.
-2. Run `go generate client/services.go` to create a mock for your new methods. This will update [client/mocks/services.go](./client/mocks/services.go) automatically
-3. Create a file under `resources/` that follows the pattern of `<service>_<resource>`.
-4. In that file, create a function that returns a `*schema.Table`
-5. In [resources/provider.go](./resources/provider.go), add a mapping between the function you just created and the name of the resource that will be used in the config yml file.
-6. In [client/config.go](./client/config.go), add the key that you used in the map in the previous step to the config template
+1. Run `go generate client/services.go` to create a mock for your new methods. This will update [client/mocks/services.go](./client/mocks/services.go) automatically
+1. Create a file under `resources/` that follows the pattern of `<service>_<resource>`.
+1. In that file, create a function that returns a `*schema.Table`
+1. In [resources/provider.go](./resources/provider.go), add a mapping between the function you just created and the name of the resource that will be used in the config yml file.
+1. In [client/config.go](./client/config.go), add the key that you used in the map in the previous step to the config template
+1. Add a test in [clients/mocks/mock_test.go](./clients/../client/mocks/mock_test.go) for the resource following the existing examples
 
 ### Implementation
 

--- a/adding_a_new_resource.md
+++ b/adding_a_new_resource.md
@@ -1,0 +1,50 @@
+# Adding a new resource
+
+Some information can be found in the [docs for developing a new provider](https://docs.cloudquery.io/developers/developing-new-provider).
+
+As a prerequisite, in [aws-sdk-go-v2](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2) ensure API calls exist to list/describe the desired resource, and make note of:
+
+   - to which aws service the resource belongs
+   - the schema of the returned object(s)
+
+## Setting up the service
+
+If the service to which the resource belongs has not been used before in cq-provider-aws, there are a few steps that need to be done to configure it.
+
+1. Create the service interface in [client/services.go](./client/services.go)
+1. Add the service to the `Services` struct in the [client/client.go](./client/client.go)
+1. Init the service in the `initServices` function in [client/client.go](./client/client.go)
+1. Run `go generate client/services.go` to create a mock for your new service. This will update [client/mocks/services.go](./client/mocks/services.go) automatically
+
+## Setting up the resource
+
+### Skeleton
+
+1. In [client/services.go](./client/services.go), update the service interface and add the method(s) that you will be using to fetch the data from the aws sdk.
+2. Run `go generate client/services.go` to create a mock for your new methods. This will update [client/mocks/services.go](./client/mocks/services.go) automatically
+3. Create a file under `resources/` that follows the pattern of `<service>_<resource>`.
+4. In that file, create a function that returns a `*schema.Table`
+5. In [resources/provider.go](./resources/provider.go), add a mapping between the function you just created and the name of the resource that will be used in the config yml file.
+6. In [client/config.go](./client/config.go), add the key that you used in the map in the previous step to the config template
+
+### Implementation
+
+Now that the skeleton has been set up, you can start to actually implement the resource. This consists of two parts: 
+
+1. Defining the schema
+1. Implementing resolver functions
+
+#### Defining the schema
+
+It is recommended that you look at a few existing resources as examples and also read through the comments on the source code for the [Table](https://github.com/cloudquery/cq-provider-sdk/blob/main/provider/schema/table.go) and [Column](https://github.com/cloudquery/cq-provider-sdk/blob/main/provider/schema/column.go) implementations for details.
+
+For noncomplex fields, the SDK can directly resolve them into `Column`s for you, so all you need to do is specify the `Name` and the `Type`.
+
+For complex fields or fields that require further API calls, you can defined your own `Resolver` for the `Column`.
+
+#### Implementing Resolver Functions
+
+A few important things to note when adding functions that call the AWS API:
+
+- If possible, always use an API call that allows you to fetch many resources at once
+- Take pagination into account. Ensure you fetch **all** of the resources

--- a/client/config.go
+++ b/client/config.go
@@ -37,6 +37,7 @@ const DefaultConfigYaml = `
       - name: cloudwatch.alarms
       - name: cloudwatchlogs.filters
       - name: directconnect.gateways
+      - name: directconnect.virtual_interfaces
       - name: ec2.customer_gateways
       - name: ec2.flow_logs
       - name: ec2.images

--- a/client/mocks/builders_test.go
+++ b/client/mocks/builders_test.go
@@ -248,6 +248,22 @@ func buildDirectconnectGatewaysMock(t *testing.T, ctrl *gomock.Controller) clien
 	}
 }
 
+func buildDirectconnectVirtualInterfacesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockDirectconnectClient(ctrl)
+	l := directconnectTypes.VirtualInterface{}
+	err := faker.FakeData(&l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.EXPECT().DescribeVirtualInterfaces(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&directconnect.DescribeVirtualInterfacesOutput{
+			VirtualInterfaces: []directconnectTypes.VirtualInterface{l},
+		}, nil)
+	return client.Services{
+		Directconnect: m,
+	}
+}
+
 func buildEc2ByoipCidrsMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockEc2Client(ctrl)
 	l := ec2Types.ByoipCidr{}

--- a/client/mocks/mock_test.go
+++ b/client/mocks/mock_test.go
@@ -76,6 +76,11 @@ func TestResources(t *testing.T) {
 			mainTable:   resources.DirectconnectGateways(),
 		},
 		{
+			resource:    "directconnect.virtual_interfaces",
+			mockBuilder: buildDirectconnectVirtualInterfacesMock,
+			mainTable:   resources.DirectconnectVirtualInterfaces(),
+		},
+		{
 			resource:    "ec2.byoip_cidrs",
 			mockBuilder: buildEc2ByoipCidrsMock,
 			mainTable:   resources.Ec2ByoipCidrs(),

--- a/client/mocks/services.go
+++ b/client/mocks/services.go
@@ -287,6 +287,26 @@ func (mr *MockDirectconnectClientMockRecorder) DescribeDirectConnectGateways(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDirectConnectGateways", reflect.TypeOf((*MockDirectconnectClient)(nil).DescribeDirectConnectGateways), varargs...)
 }
 
+// DescribeVirtualInterfaces mocks base method.
+func (m *MockDirectconnectClient) DescribeVirtualInterfaces(arg0 context.Context, arg1 *directconnect.DescribeVirtualInterfacesInput, arg2 ...func(*directconnect.Options)) (*directconnect.DescribeVirtualInterfacesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeVirtualInterfaces", varargs...)
+	ret0, _ := ret[0].(*directconnect.DescribeVirtualInterfacesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeVirtualInterfaces indicates an expected call of DescribeVirtualInterfaces.
+func (mr *MockDirectconnectClientMockRecorder) DescribeVirtualInterfaces(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVirtualInterfaces", reflect.TypeOf((*MockDirectconnectClient)(nil).DescribeVirtualInterfaces), varargs...)
+}
+
 // MockEc2Client is a mock of Ec2Client interface.
 type MockEc2Client struct {
 	ctrl     *gomock.Controller

--- a/client/services.go
+++ b/client/services.go
@@ -50,6 +50,7 @@ type CloudwatchLogsClient interface {
 
 type DirectconnectClient interface {
 	DescribeDirectConnectGateways(ctx context.Context, params *directconnect.DescribeDirectConnectGatewaysInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeDirectConnectGatewaysOutput, error)
+	DescribeVirtualInterfaces(ctx context.Context, params *directconnect.DescribeVirtualInterfacesInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeVirtualInterfacesOutput, error)
 }
 
 type Ec2Client interface {

--- a/resources/directconnect_virtual_interfaces.go
+++ b/resources/directconnect_virtual_interfaces.go
@@ -1,0 +1,215 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/directconnect"
+	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
+	"github.com/cloudquery/cq-provider-aws/client"
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+)
+
+func DirectconnectVirtualInterfaces() *schema.Table {
+	return &schema.Table{
+		Name:         "aws_directconnect_virtual_interfaces",
+		Resolver:     fetchDirectconnectVirtualInterfaces,
+		Multiplex:    client.AccountRegionMultiplex,
+		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		DeleteFilter: client.DeleteAccountRegionFilter,
+		Columns: []schema.Column{
+			{
+				Name:     "account_id",
+				Type:     schema.TypeString,
+				Resolver: client.ResolveAWSAccount,
+			},
+			{
+				Name: "address_family",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "amazon_address",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "amazon_side_asn",
+				Type: schema.TypeBigInt,
+			},
+			{
+				Name: "asn",
+				Type: schema.TypeInt,
+			},
+			{
+				Name: "auth_key",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "aws_device_v2",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "connection_id",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "customer_address",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "customer_router_config",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "direct_connect_gateway_id",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "jumbo_frame_capable",
+				Type: schema.TypeBool,
+			},
+			{
+				Name: "location",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "mtu",
+				Type: schema.TypeInt,
+			},
+			{
+				Name: "owner_account",
+				Type: schema.TypeString,
+			},
+			{
+				Name:     "region",
+				Type:     schema.TypeString,
+				Resolver: client.ResolveAWSRegion,
+			},
+			{
+				Name:     "route_filter_prefixes",
+				Type:     schema.TypeStringArray,
+				Resolver: resolveVirtualInterfaceRouteFilterPrefixes,
+			},
+			{
+				Name:     "tags",
+				Type:     schema.TypeJSON,
+				Resolver: resolveDirectconnectVirtualInterfaceTags,
+			},
+			{
+				Name: "virtual_gateway_id",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "virtual_interface_id",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "virtual_interface_name",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "virtual_interface_state",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "virtual_interface_type",
+				Type: schema.TypeString,
+			},
+			{
+				Name: "vlan",
+				Type: schema.TypeInt,
+			},
+		},
+		Relations: []*schema.Table{
+			{
+				Name:     "aws_directconnect_virtual_interface_bgp_peers",
+				Resolver: fetchVirtualInterfaceBGPPeers,
+				Columns: []schema.Column{
+					{
+						Name:     "virtual_interface_id",
+						Type:     schema.TypeUUID,
+						Resolver: schema.ParentIdResolver,
+					},
+					{
+						Name: "address_family",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "amazon_address",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "asn",
+						Type: schema.TypeInt,
+					},
+					{
+						Name: "auth_key",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "aws_device_v2",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "bgp_peer_id",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "bgp_peer_state",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "bgp_status",
+						Type: schema.TypeString,
+					},
+					{
+						Name: "customer_address",
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func resolveVirtualInterfaceRouteFilterPrefixes(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, _ schema.Column) error {
+	r := resource.Item.(types.VirtualInterface)
+	routeFilterPrefixes := make([]*string, len(r.RouteFilterPrefixes))
+	for i, prefix := range r.RouteFilterPrefixes {
+		routeFilterPrefixes[i] = prefix.Cidr
+	}
+	resource.Set("route_filter_prefixes", routeFilterPrefixes)
+	return nil
+}
+
+func fetchVirtualInterfaceBGPPeers(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan interface{}) error {
+	virtualInterface, ok := parent.Item.(types.VirtualInterface)
+	if !ok {
+		return fmt.Errorf("not a direct connect virtual interface")
+	}
+	res <- virtualInterface.BgpPeers
+	return nil
+}
+
+func resolveDirectconnectVirtualInterfaceTags(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, _ schema.Column) error {
+	r := resource.Item.(types.VirtualInterface)
+	tags := map[string]*string{}
+	for _, t := range r.Tags {
+		tags[*t.Key] = t.Value
+	}
+	resource.Set("tags", tags)
+	return nil
+}
+
+func fetchDirectconnectVirtualInterfaces(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan interface{}) error {
+	var config directconnect.DescribeVirtualInterfacesInput
+	c := meta.(*client.Client)
+	svc := c.Services().Directconnect
+	output, err := svc.DescribeVirtualInterfaces(ctx, &config, func(options *directconnect.Options) {
+		options.Region = c.Region
+	})
+	if err != nil {
+		return err
+	}
+	res <- output.VirtualInterfaces
+	return nil
+}

--- a/resources/provider.go
+++ b/resources/provider.go
@@ -17,6 +17,7 @@ func Provider() *provider.Provider {
 			"cloudwatchlogs.filters":            CloudwatchlogsFilters(),
 			"s3.buckets":                        S3Buckets(),
 			"directconnect.gateways":            DirectconnectGateways(),
+			"directconnect.virtual_interfaces":  DirectconnectVirtualInterfaces(),
 			"ec2.byoip_cidrs":                   Ec2ByoipCidrs(),
 			"ec2.customer_gateways":             Ec2CustomerGateways(),
 			"ec2.flow_logs":                     Ec2FlowLogs(),


### PR DESCRIPTION
I looked but it doesn't seem like this endpoint is paginated at all. There is no nextToken in the output: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/directconnect@v1.3.1#DescribeVirtualInterfacesOutput

and the [method call docs](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/directconnect@v1.3.1#Client.DescribeVirtualInterfaces) says it returns "all virtual interfaces for an AWS account"