### PR TITLE
fix issue 82

### DIFF
--- a/client/mocks/builders_test.go
+++ b/client/mocks/builders_test.go
@@ -996,55 +996,6 @@ func buildRdsDBSubnetGroups(t *testing.T, ctrl *gomock.Controller) client.Servic
 	}
 }
 
-func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
-	m := mocks.NewMockIamClient(ctrl)
-	g := iamTypes.Group{}
-	err := faker.FakeData(&g)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p := iamTypes.AttachedPolicy{}
-	err = faker.FakeData(&p)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	m.EXPECT().ListGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&iam.ListGroupsOutput{
-			Groups: []iamTypes.Group{g},
-		}, nil)
-	m.EXPECT().ListAttachedGroupPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&iam.ListAttachedGroupPoliciesOutput{
-			AttachedPolicies: []iamTypes.AttachedPolicy{p},
-		}, nil)
-
-	//list policies
-	var l []string
-	err = faker.FakeData(&l)
-	if err != nil {
-		t.Fatal(err)
-	}
-	m.EXPECT().ListGroupPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&iam.ListGroupPoliciesOutput{
-			PolicyNames: l,
-		}, nil)
-
-	//get policy
-	gp := iam.GetGroupPolicyOutput{}
-	err = faker.FakeData(&gp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	document := "{\"test\": {\"t1\":1}}"
-	gp.PolicyDocument = &document
-	m.EXPECT().GetGroupPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&gp, nil)
-	return client.Services{
-		IAM: m,
-	}
-}
-
 func buildIamPolicies(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockIamClient(ctrl)
 	g := iamTypes.ManagedPolicyDetail{}

--- a/client/mocks/mock_test.go
+++ b/client/mocks/mock_test.go
@@ -241,11 +241,6 @@ func TestResources(t *testing.T) {
 			mainTable:   resources.SnsSubscriptions(),
 		},
 		{
-			resource:    "iam.groups",
-			mainTable:   resources.IamGroups(),
-			mockBuilder: buildIamGroups,
-		},
-		{
 			resource:    "iam.policies",
 			mainTable:   resources.IamPolicies(),
 			mockBuilder: buildIamPolicies,

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.1.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.2.1
-	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.4.0
 	github.com/cloudquery/cq-provider-sdk v0.2.3
 	github.com/cloudquery/faker/v3 v3.7.4

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.2.1 h1:fc4agBKsSeBinQAV4ornEhbauSz0Tu0s9G0+KHhrRWY=
-github.com/cloudquery/cq-provider-sdk v0.2.1/go.mod h1:cdn/dDr5A1zfmSFmW2qDmwD5J+8v/o33glMt2+u36KM=
 github.com/cloudquery/cq-provider-sdk v0.2.3 h1:aY8jp+0U8EjWszNFr77b+aTzCDh0nyzLimlm+Xpo0iA=
 github.com/cloudquery/cq-provider-sdk v0.2.3/go.mod h1:cdn/dDr5A1zfmSFmW2qDmwD5J+8v/o33glMt2+u36KM=
 github.com/cloudquery/faker/v3 v3.7.4 h1:cCcU3r0yHpS0gqKj9rRKAGS0/hY33fBxbqCNFtDD4ec=

--- a/resources/iam_group_policies.go
+++ b/resources/iam_group_policies.go
@@ -19,7 +19,7 @@ import (
 
 func iamGroupPolicies() *schema.Table {
 	return &schema.Table{
-		Name:         "aws_iam_group_policies",
+		Name:         "aws_iam_group_attached_policies",
 		Resolver:     fetchIamGroupPolicies,
 		Multiplex:    client.AccountMultiplex,
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,

--- a/resources/iam_group_policies.go
+++ b/resources/iam_group_policies.go
@@ -19,7 +19,7 @@ import (
 
 func iamGroupPolicies() *schema.Table {
 	return &schema.Table{
-		Name:         "aws_iam_group_attached_policies",
+		Name:         "aws_iam_group_inline_policies",
 		Resolver:     fetchIamGroupPolicies,
 		Multiplex:    client.AccountMultiplex,
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,

--- a/resources/iam_groups_test.go
+++ b/resources/iam_groups_test.go
@@ -1,0 +1,65 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/cloudquery/cq-provider-aws/client"
+	"github.com/cloudquery/cq-provider-aws/client/mocks"
+	"github.com/cloudquery/faker/v3"
+	"github.com/golang/mock/gomock"
+)
+
+func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockIamClient(ctrl)
+	g := iamTypes.Group{}
+	err := faker.FakeData(&g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := iamTypes.AttachedPolicy{}
+	err = faker.FakeData(&p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.EXPECT().ListGroups(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&iam.ListGroupsOutput{
+			Groups: []iamTypes.Group{g},
+		}, nil)
+	m.EXPECT().ListAttachedGroupPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&iam.ListAttachedGroupPoliciesOutput{
+			AttachedPolicies: []iamTypes.AttachedPolicy{p},
+		}, nil)
+
+	//list policies
+	var l []string
+	err = faker.FakeData(&l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.EXPECT().ListGroupPolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&iam.ListGroupPoliciesOutput{
+			PolicyNames: l,
+		}, nil)
+
+	//get policy
+	gp := iam.GetGroupPolicyOutput{}
+	err = faker.FakeData(&gp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := "{\"test\": {\"t1\":1}}"
+	gp.PolicyDocument = &document
+	m.EXPECT().GetGroupPolicy(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&gp, nil)
+	return client.Services{
+		IAM: m,
+	}
+}
+
+func TestIamGroups(t *testing.T) {
+	awsTestHelper(t, IamRoles(), buildIamRoles, TestOptions{})
+}

--- a/resources/iam_groups_test.go
+++ b/resources/iam_groups_test.go
@@ -61,5 +61,5 @@ func buildIamGroups(t *testing.T, ctrl *gomock.Controller) client.Services {
 }
 
 func TestIamGroups(t *testing.T) {
-	awsTestHelper(t, IamRoles(), buildIamRoles, TestOptions{})
+	awsTestHelper(t, IamGroups(), buildIamGroups, TestOptions{})
 }

--- a/resources/iam_role_policies.go
+++ b/resources/iam_role_policies.go
@@ -19,7 +19,7 @@ import (
 
 func iamRolePolicies() *schema.Table {
 	return &schema.Table{
-		Name:         "aws_iam_role_policies",
+		Name:         "aws_iam_role_attached_policies",
 		Resolver:     fetchIamRolePolicies,
 		Multiplex:    client.AccountMultiplex,
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,

--- a/resources/iam_role_policies.go
+++ b/resources/iam_role_policies.go
@@ -19,7 +19,7 @@ import (
 
 func iamRolePolicies() *schema.Table {
 	return &schema.Table{
-		Name:         "aws_iam_role_attached_policies",
+		Name:         "aws_iam_role_inline_policies",
 		Resolver:     fetchIamRolePolicies,
 		Multiplex:    client.AccountMultiplex,
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,

--- a/resources/iam_roles_test.go
+++ b/resources/iam_roles_test.go
@@ -47,7 +47,7 @@ func buildIamRoles(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&iam.ListRolePoliciesOutput{
 			PolicyNames: l,
-		}, nil)
+		}, nil).AnyTimes()
 
 	//get policy
 	pd := iam.GetRolePolicyOutput{}


### PR DESCRIPTION
Issue is rarely reproducible because it happens only when cq-provider tries to get policies of role/group that already does not exist. That means that it can happen in highly dynamic environment.
 - Added handler for `NoSuchEntity` api error;
 - resource column `policies` has been renamed into `attached_policies`
 - resource relation `gcp_iam_role_policies` has been renamed into `gcp_iam_role_inline_policies`
This issue is more complex because it can happen with all the other resources when relation is requested for removed resource.
