### PR TITLE
Updated the .goreleaser.yaml with arm64 build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,11 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
 archives:
   -
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"


### PR DESCRIPTION
Currently, the cloudquery AWS provider doesn't have arm64 build in `.goreleaser.yaml`. Added `arm64` build for cq-provider-aws.