### PR TITLE
Run integration tests only when env var is set

### DIFF
--- a/resources/integration_tests/integration_test.go
+++ b/resources/integration_tests/integration_test.go
@@ -1,6 +1,8 @@
 package integration_tests
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/cloudquery/cq-provider-aws/client"
@@ -8,6 +10,10 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/provider/providertest"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 )
+
+// IntegrationTestsEnabledVar is the name of the environment variable that enables integration tests from this package.
+// Set it to one of "1", "y", "yes", "true" to enable the tests.
+const IntegrationTestsEnabledVar = "INTEGRATION_TESTS"
 
 func awsTestIntegrationHelper(t *testing.T, table *schema.Table, verificationBuilder func(res *providertest.ResourceIntegrationTestData) providertest.ResourceIntegrationVerification) {
 	cfg := client.Config{
@@ -21,4 +27,21 @@ func awsTestIntegrationHelper(t *testing.T, table *schema.Table, verificationBui
 		Configure:           client.Configure,
 		VerificationBuilder: verificationBuilder,
 	})
+}
+
+func TestMain(m *testing.M) {
+	enabled := os.Getenv(IntegrationTestsEnabledVar)
+	enabledValues := map[string]struct{}{
+		"1":       {},
+		"y":       {},
+		"yes":     {},
+		"true":    {},
+		"enable":  {},
+		"enabled": {},
+	}
+	if _, ok := enabledValues[enabled]; ok {
+		os.Exit(m.Run())
+	} else {
+		fmt.Fprintln(os.Stderr, "Integration tests are skipped. Set INTEGRATION_TESTS=1 environment variable to enable.")
+	}
 }


### PR DESCRIPTION
Skip integration tests if environment variable is not set. This helps to avoid running them by IDE/ editor each time you touch some files.