### PR TITLE
feat: directconnect lags

### DIFF
--- a/adding_a_new_resource.md
+++ b/adding_a_new_resource.md
@@ -26,7 +26,8 @@ If the service to which the resource belongs has not been used before in cq-prov
 1. Create a file under `resources/` that follows the pattern of `<service>_<resource>`.
 1. In that file, create a function that returns a `*schema.Table`
 1. In [resources/provider.go](./resources/provider.go), add a mapping between the function you just created and the name of the resource that will be used in the config yml file.
-1. Add a test in [clients/mocks/resources_test.go](./client/mocks/resources_test.go) and the corresponding test implementation in [clients/mocks/builders_test.go](./client/mocks/builders_test.go) for the resource following the existing examples.
+1. Add a test file at `resources/<service>_<resource>_test.go`. Follow other examples to create a test for the resource.
+1. Run `go run docs/docs.go` to generate the documentation for the new resource
 
 ### Implementation
 

--- a/client/mocks/mock_directconnect.go
+++ b/client/mocks/mock_directconnect.go
@@ -115,6 +115,26 @@ func (mr *MockDirectconnectClientMockRecorder) DescribeDirectConnectGateways(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDirectConnectGateways", reflect.TypeOf((*MockDirectconnectClient)(nil).DescribeDirectConnectGateways), varargs...)
 }
 
+// DescribeLags mocks base method.
+func (m *MockDirectconnectClient) DescribeLags(arg0 context.Context, arg1 *directconnect.DescribeLagsInput, arg2 ...func(*directconnect.Options)) (*directconnect.DescribeLagsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeLags", varargs...)
+	ret0, _ := ret[0].(*directconnect.DescribeLagsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeLags indicates an expected call of DescribeLags.
+func (mr *MockDirectconnectClientMockRecorder) DescribeLags(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLags", reflect.TypeOf((*MockDirectconnectClient)(nil).DescribeLags), varargs...)
+}
+
 // DescribeVirtualGateways mocks base method.
 func (m *MockDirectconnectClient) DescribeVirtualGateways(arg0 context.Context, arg1 *directconnect.DescribeVirtualGatewaysInput, arg2 ...func(*directconnect.Options)) (*directconnect.DescribeVirtualGatewaysOutput, error) {
 	m.ctrl.T.Helper()

--- a/client/services.go
+++ b/client/services.go
@@ -133,6 +133,7 @@ type DirectconnectClient interface {
 	DescribeDirectConnectGateways(ctx context.Context, params *directconnect.DescribeDirectConnectGatewaysInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeDirectConnectGatewaysOutput, error)
 	DescribeDirectConnectGatewayAssociations(ctx context.Context, params *directconnect.DescribeDirectConnectGatewayAssociationsInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeDirectConnectGatewayAssociationsOutput, error)
 	DescribeDirectConnectGatewayAttachments(ctx context.Context, params *directconnect.DescribeDirectConnectGatewayAttachmentsInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeDirectConnectGatewayAttachmentsOutput, error)
+	DescribeLags(ctx context.Context, params *directconnect.DescribeLagsInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeLagsOutput, error)
 	DescribeVirtualGateways(ctx context.Context, params *directconnect.DescribeVirtualGatewaysInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeVirtualGatewaysOutput, error)
 	DescribeVirtualInterfaces(ctx context.Context, params *directconnect.DescribeVirtualInterfacesInput, optFns ...func(*directconnect.Options)) (*directconnect.DescribeVirtualInterfacesOutput, error)
 }

--- a/docs/tables/aws_directconnect_lag_mac_sec_keys.md
+++ b/docs/tables/aws_directconnect_lag_mac_sec_keys.md
@@ -1,0 +1,12 @@
+
+# Table: aws_directconnect_lag_mac_sec_keys
+The MAC Security (MACsec) security keys associated with the LAG.
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|lag_cq_id|uuid|Unique CloudQuery ID of aws_directconnect_lags table (FK)|
+|lag_id|text|The ID of the LAG.|
+|ckn|text|The Connection Key Name (CKN) for the MAC Security secret key.|
+|secret_arn|text|The Amazon Resource Name (ARN) of the MAC Security (MACsec) secret key.|
+|start_on|text|The date that the MAC Security (MACsec) secret key takes effect. The value is displayed in UTC format.|
+|state|text|The state of the MAC Security secret key. The possible values are: associating, associated, disassociating, disassociated|

--- a/docs/tables/aws_directconnect_lags.md
+++ b/docs/tables/aws_directconnect_lags.md
@@ -15,7 +15,7 @@ Information about Direct Connect Link Aggregation Group (LAG)
 |jumbo_frame_capable|boolean|Indicates whether jumbo frames (9001 MTU) are supported.|
 |id|text|The ID of the LAG.|
 |name|text|The name of the LAG.|
-|lag_state|text|The state of the LAG. Possible values are: requested, pending, available, down, deleting, deleted, unknown|
+|state|text|The state of the LAG. Possible values are: requested, pending, available, down, deleting, deleted, unknown|
 |location|text|The location of the LAG.|
 |mac_sec_capable|boolean|Indicates whether the LAG supports MAC Security (MACsec).|
 |minimum_links|integer|The minimum number of physical dedicated connections that must be operational for the LAG itself to be operational.|

--- a/docs/tables/aws_directconnect_lags.md
+++ b/docs/tables/aws_directconnect_lags.md
@@ -1,0 +1,25 @@
+
+# Table: aws_directconnect_lags
+Information about Direct Connect Link Aggregation Group (LAG)
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|account_id|text|The AWS Account ID of the resource.|
+|region|text|The AWS Region of the resource.|
+|allows_hosted_connections|boolean|Indicates whether the LAG can host other connections.|
+|aws_device_v2|text|The AWS Direct Connect endpoint that hosts the LAG.|
+|connection_ids|text[]|The list of IDs of Direct Connect Connections bundled by the LAG|
+|connections_bandwidth|text|The individual bandwidth of the physical connections bundled by the LAG.|
+|encryption_mode|text|The LAG MAC Security (MACsec) encryption mode.|
+|has_logical_redundancy|text|Indicates whether the LAG supports a secondary BGP peer in the same address family (IPv4/IPv6).|
+|jumbo_frame_capable|boolean|Indicates whether jumbo frames (9001 MTU) are supported.|
+|id|text|The ID of the LAG.|
+|name|text|The name of the LAG.|
+|lag_state|text|The state of the LAG. Possible values are: requested, pending, available, down, deleting, deleted, unknown|
+|location|text|The location of the LAG.|
+|mac_sec_capable|boolean|Indicates whether the LAG supports MAC Security (MACsec).|
+|minimum_links|integer|The minimum number of physical dedicated connections that must be operational for the LAG itself to be operational.|
+|number_of_connections|integer|The number of physical dedicated connections bundled by the LAG, up to a maximum of 10.|
+|owner_account|text|The ID of the AWS account that owns the LAG.|
+|provider_name|text|The name of the service provider associated with the LAG.|
+|tags|jsonb|The tags associated with the LAG.|

--- a/resources/directconnect_lags.go
+++ b/resources/directconnect_lags.go
@@ -1,0 +1,213 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/directconnect"
+	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
+	"github.com/cloudquery/cq-provider-aws/client"
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+)
+
+func DirectconnectLags() *schema.Table {
+	return &schema.Table{
+		Name:         "aws_directconnect_lags",
+		Description:  "Information about Direct Connect Link Aggregation Group (LAG)",
+		Resolver:     fetchDirectconnectLags,
+		Multiplex:    client.AccountRegionMultiplex,
+		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		DeleteFilter: client.DeleteAccountRegionFilter,
+		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
+		Columns: []schema.Column{
+			{
+				Name:        "account_id",
+				Description: "The AWS Account ID of the resource.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAWSAccount,
+			},
+			{
+				Name:        "region",
+				Description: "The AWS Region of the resource.",
+				Type:        schema.TypeString,
+				Resolver:    client.ResolveAWSRegion,
+			},
+			{
+				Name:        "allows_hosted_connections",
+				Description: "Indicates whether the LAG can host other connections.",
+				Type:        schema.TypeBool,
+			},
+			{
+				Name:        "aws_device_v2",
+				Description: "The AWS Direct Connect endpoint that hosts the LAG.",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "connection_ids",
+				Description: "The list of IDs of Direct Connect Connections bundled by the LAG",
+				Type:        schema.TypeStringArray,
+				Resolver:    resolveDirectconnectLagConnectionIds,
+			},
+			{
+				Name:        "connections_bandwidth",
+				Description: "The individual bandwidth of the physical connections bundled by the LAG.",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "encryption_mode",
+				Description: "The LAG MAC Security (MACsec) encryption mode.",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "has_logical_redundancy",
+				Description: "Indicates whether the LAG supports a secondary BGP peer in the same address family (IPv4/IPv6).",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "jumbo_frame_capable",
+				Description: "Indicates whether jumbo frames (9001 MTU) are supported.",
+				Type:        schema.TypeBool,
+			},
+			{
+				Name:        "id",
+				Description: "The ID of the LAG.",
+				Type:        schema.TypeString,
+				Resolver:    schema.PathResolver("LagId"),
+			},
+			{
+				Name:        "name",
+				Description: "The name of the LAG.",
+				Type:        schema.TypeString,
+				Resolver:    schema.PathResolver("LagName"),
+			},
+			{
+				Name:        "lag_state",
+				Description: "The state of the LAG. Possible values are: requested, pending, available, down, deleting, deleted, unknown",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "location",
+				Description: "The location of the LAG.",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "mac_sec_capable",
+				Description: "Indicates whether the LAG supports MAC Security (MACsec).",
+				Type:        schema.TypeBool,
+			},
+			{
+				Name:        "minimum_links",
+				Description: "The minimum number of physical dedicated connections that must be operational for the LAG itself to be operational.",
+				Type:        schema.TypeInt,
+			},
+			{
+				Name:        "number_of_connections",
+				Description: "The number of physical dedicated connections bundled by the LAG, up to a maximum of 10.",
+				Type:        schema.TypeInt,
+			},
+			{
+				Name:        "owner_account",
+				Description: "The ID of the AWS account that owns the LAG.",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "provider_name",
+				Description: "The name of the service provider associated with the LAG.",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "tags",
+				Description: "The tags associated with the LAG.",
+				Type:        schema.TypeJSON,
+				Resolver:    resolveDirectconnectLagTags,
+			},
+		},
+		Relations: []*schema.Table{
+			{
+				Name:        "aws_directconnect_lag_mac_sec_keys",
+				Description: "The MAC Security (MACsec) security keys associated with the LAG.",
+				Resolver:    fetchDirectconnectLagMacSecKeys,
+				Options:     schema.TableCreationOptions{PrimaryKeys: []string{"lag_cq_id", "secret_arn"}},
+				Columns: []schema.Column{
+					{
+						Name:        "lag_cq_id",
+						Description: "Unique CloudQuery ID of aws_directconnect_lags table (FK)",
+						Type:        schema.TypeUUID,
+						Resolver:    schema.ParentIdResolver,
+					},
+					{
+						Name:        "lag_id",
+						Description: "The ID of the LAG.",
+						Type:        schema.TypeString,
+						Resolver:    schema.ParentResourceFieldResolver("id"),
+					},
+					{
+						Name:        "ckn",
+						Description: "The Connection Key Name (CKN) for the MAC Security secret key.",
+						Type:        schema.TypeString,
+					},
+					{
+						Name:        "secret_arn",
+						Description: "The Amazon Resource Name (ARN) of the MAC Security (MACsec) secret key.",
+						Type:        schema.TypeString,
+						Resolver:    schema.PathResolver("SecretARN"),
+					},
+					{
+						Name:        "start_on",
+						Description: "The date that the MAC Security (MACsec) secret key takes effect. The value is displayed in UTC format.",
+						Type:        schema.TypeString,
+					},
+					{
+						Name:        "state",
+						Description: "The state of the MAC Security secret key. The possible values are: associating, associated, disassociating, disassociated",
+						Type:        schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+// ====================================================================================================================
+//                                               Table Resolver Functions
+// ====================================================================================================================
+func fetchDirectconnectLags(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan interface{}) error {
+	var config directconnect.DescribeLagsInput
+	c := meta.(*client.Client)
+	svc := c.Services().Directconnect
+	output, err := svc.DescribeLags(ctx, &config, func(options *directconnect.Options) {
+		options.Region = c.Region
+	})
+	if err != nil {
+		return err
+	}
+	res <- output.Lags
+	return nil
+}
+
+func resolveDirectconnectLagTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
+	r := resource.Item.(types.Lag)
+	tags := map[string]*string{}
+	for _, t := range r.Tags {
+		tags[*t.Key] = t.Value
+	}
+	return resource.Set("tags", tags)
+}
+
+func fetchDirectconnectLagMacSecKeys(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan interface{}) error {
+	connection, ok := parent.Item.(types.Lag)
+	if !ok {
+		return fmt.Errorf("not a direct connect LAG")
+	}
+	res <- connection.MacSecKeys
+	return nil
+}
+
+func resolveDirectconnectLagConnectionIds(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
+	r := resource.Item.(types.Lag)
+	connectionIds := make([]*string, len(r.Connections))
+	for i, connection := range r.Connections {
+		connectionIds[i] = connection.ConnectionId
+	}
+	return resource.Set("connection_ids", connectionIds)
+}

--- a/resources/directconnect_lags.go
+++ b/resources/directconnect_lags.go
@@ -81,9 +81,10 @@ func DirectconnectLags() *schema.Table {
 				Resolver:    schema.PathResolver("LagName"),
 			},
 			{
-				Name:        "lag_state",
+				Name:        "state",
 				Description: "The state of the LAG. Possible values are: requested, pending, available, down, deleting, deleted, unknown",
 				Type:        schema.TypeString,
+				Resolver:    schema.PathResolver("LagState"),
 			},
 			{
 				Name:        "location",

--- a/resources/directconnect_lags_test.go
+++ b/resources/directconnect_lags_test.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/directconnect"
+	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
+	"github.com/cloudquery/cq-provider-aws/client"
+	"github.com/cloudquery/cq-provider-aws/client/mocks"
+	"github.com/cloudquery/faker/v3"
+	"github.com/golang/mock/gomock"
+)
+
+func buildDirectconnectLag(t *testing.T, ctrl *gomock.Controller) client.Services {
+	m := mocks.NewMockDirectconnectClient(ctrl)
+	lag := types.Lag{}
+	err := faker.FakeData(&lag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.EXPECT().DescribeLags(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&directconnect.DescribeLagsOutput{
+			Lags: []types.Lag{lag},
+		}, nil)
+	return client.Services{
+		Directconnect: m,
+	}
+}
+
+func TestDirectconnectLag(t *testing.T) {
+	awsTestHelper(t, DirectconnectLags(), buildDirectconnectLag, TestOptions{})
+}

--- a/resources/provider.go
+++ b/resources/provider.go
@@ -32,6 +32,7 @@ func Provider() *provider.Provider {
 			"s3.buckets":                            S3Buckets(),
 			"directconnect.connections":             DirectconnectConnections(),
 			"directconnect.gateways":                DirectconnectGateways(),
+			"directconnect.lags":                    DirectconnectLags(),
 			"directconnect.virtual_gateways":        DirectconnectVirtualGateways(),
 			"directconnect.virtual_interfaces":      DirectconnectVirtualInterfaces(),
 			"cognito.identity_pools":                CognitoIdentityPools(),


### PR DESCRIPTION
Lag schema: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/directconnect@v1.4.1/types#Lag

As we are already capturing DirectConnect Connections in a separate table, I opted to not resave that data, and instead just save the connectionIds in a StringArray.

Connection -> Lag is a Many:1 relationship, but not all connections necessarily have a Lag. Perhaps this is a scenario where we could introduce nullable FKs or something like that?