### PR TITLE
Use credentials cache

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -257,7 +257,8 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 					opts.ExternalID = &account.ExternalID
 				})
 			}
-			awsCfg.Credentials = stscreds.NewAssumeRoleProvider(sts.NewFromConfig(awsCfg), account.RoleARN, opts...)
+			provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(awsCfg), account.RoleARN, opts...)
+			awsCfg.Credentials = aws.NewCredentialsCache(provider)
 		case account.ID != "default":
 			awsCfg, err = config.LoadDefaultConfig(
 				ctx,


### PR DESCRIPTION
According to note here (https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specify-credentials-programmatically) all providers must be wrapped in credentials cache.