### PR TITLE
added skip GetFunctionCodeSigningConfig for container functions

### DIFF
--- a/resources/lambda_functions.go
+++ b/resources/lambda_functions.go
@@ -992,7 +992,9 @@ func resolvePolicyCodeSigningConfig(ctx context.Context, meta schema.ClientMeta,
 		}
 	}
 
-	if resource.Get("code_image_uri") != nil {
+	//skip getting CodeSigningConfig since containerized lambda functions does not support this feature
+	lambdaType := resource.Get("code_repository_type").(*string)
+	if *lambdaType == "ECR" {
 		return nil
 	}
 


### PR DESCRIPTION
fixes this error:
```
ts=2021-10-28T11:01:44Z level=ERROR msg="failed to resolve resource: post resource resolver failed: operation error Lambda: GetFunctionCodeSigningConfig, https response error StatusCode: 400, RequestID: 6faf6eb2-8cde-417e-b7ac-e18773ba9011, InvalidParameterValueException: Code signing is not supported for functions created with container images." identifier=partialFetchError org_id=c0ab1f38-18b6-4636-984c-6088c9b7b093 providerName=aws rootPrimaryKeyValues=[] rootTableName= tableName=aws_lambda_functions
```