### PR TITLE
Cloudtrail tags fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this provider will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2021-11-01
+###### SDK Version: 0.5.0
+
+### :spider: Fixed
+* Fixed [#236](https://github.com/cloudquery/cq-provider-aws/issues/236) error in `aws_cloud_trails` get tags request because ARNs in request were from different regions
 
 ## [v0.6.1] - 2021-10-29
 ###### SDK Version: 0.5.0


### PR DESCRIPTION
cloudtrails tag list sometimes returned the error because region in cloudtrail ARN and in call options were different. Now cloudtrails are aggregated by region before doing get tags call.
fixes #236 