### PR TITLE
Bugfix/ingore dns error

### DIFF
--- a/client/helpers.go
+++ b/client/helpers.go
@@ -85,7 +85,22 @@ func ignoreUnsupportedResourceForRegionError(err error) bool {
 	})
 	var dnsErr *net.DNSError
 	if supportedServices != nil && errors.As(err, &dnsErr) && dnsErr.IsNotFound {
-		parts := strings.Split(dnsErr.Name, ".")
+		var parts = make([]string, 0)
+
+		// if error address in local, try to parse the original error
+		if strings.HasPrefix(dnsErr.Name, "127.0.0.53:53") {
+			var re = regexp.MustCompile(`(?m).*Post "https:\/\/(.*)?\.(.*)?\.amazonaws.com\/": dial tcp:.*`)
+			if re.MatchString(err.Error()) {
+				p := re.FindAllStringSubmatch(err.Error(), -1)
+				if len(p) > 0 && len(p[0]) > 0 {
+					parts = append(parts, p[0][1])
+					parts = append(parts, p[0][2])
+				}
+			}
+		} else {
+			parts = strings.Split(dnsErr.Name, ".")
+		}
+
 		if len(parts) < 2 {
 			// usual aws domain has more than 2 parts
 			return false


### PR DESCRIPTION
<!---
Thank you very much for your contributions!
--->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
More information about running the tests [here](../docs/contributing/e2e_tests.md)
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.


More information about running the tests [here](../docs/contributing/e2e_tests.md)
-->
```
$ make testName=TestAccXXX e2e-test-with-apply
...
```