### PR TITLE
fix region filtering

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -467,7 +467,9 @@ func newRetryer(maxRetries int, maxBackoff int) func() aws.Retryer {
 func filterDisabledRegions(regions []string, enabledRegions []types.Region) []string {
 	regionsMap := map[string]bool{}
 	for _, r := range enabledRegions {
-		regionsMap[*r.RegionName] = true
+		if r.RegionName != nil && r.OptInStatus != nil && *r.OptInStatus != "not-opted-in" {
+			regionsMap[*r.RegionName] = true
+		}
 	}
 
 	var filteredRegions []string


### PR DESCRIPTION
<!---
Thank you very much for your contributions!
--->


OptInStatus can be `not-opted-in` which means the region is disabled.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
More information about running the tests [here](../docs/contributing/e2e_tests.md)
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.


More information about running the tests [here](../docs/contributing/e2e_tests.md)
-->
```
$ make testName=TestAccXXX e2e-test-with-apply
...
```