### PR TITLE
DescribeConformancePacks always returns AccessDeniedException in af-south-1

### DIFF
--- a/resources/config_conformance_pack.go
+++ b/resources/config_conformance_pack.go
@@ -94,7 +94,7 @@ func fetchConfigConformancePacks(ctx context.Context, meta schema.ClientMeta, pa
 			options.Region = c.Region
 		})
 
-		// This is a workaround untill this bug is fixed = https://github.com/aws/aws-sdk-go-v2/issues/1539
+		// This is a workaround until this bug is fixed = https://github.com/aws/aws-sdk-go-v2/issues/1539
 		if c.Region == "af-south-1" && errors.As(err, &ae) && ae.ErrorCode() == "AccessDeniedException" {
 			return nil
 		}

--- a/resources/config_conformance_pack.go
+++ b/resources/config_conformance_pack.go
@@ -2,11 +2,14 @@ package resources
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	"github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	"github.com/cloudquery/cq-provider-aws/client"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+
+	smithy "github.com/aws/smithy-go"
 )
 
 func ConfigConformancePack() *schema.Table {
@@ -85,10 +88,17 @@ func ConfigConformancePack() *schema.Table {
 func fetchConfigConformancePacks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan interface{}) error {
 	c := meta.(*client.Client)
 	config := configservice.DescribeConformancePacksInput{}
+	var ae smithy.APIError
 	for {
 		resp, err := c.Services().ConfigService.DescribeConformancePacks(ctx, &config, func(options *configservice.Options) {
 			options.Region = c.Region
 		})
+
+		// This is a workaround untill this bug is fixed = https://github.com/aws/aws-sdk-go-v2/issues/1539
+		if c.Region == "af-south-1" && errors.As(err, &ae) && ae.ErrorCode() == "AccessDeniedException" {
+			return nil
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

This is a workaround untill this bug is fixed
https://github.com/aws/aws-sdk-go-v2/issues/1539
<!---
Thank you very much for your contributions!
--->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
More information about running the tests [here](../docs/contributing/e2e_tests.md)
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.


More information about running the tests [here](../docs/contributing/e2e_tests.md)
-->
```
$ make testName=TestAccXXX e2e-test-with-apply
...
```