### PR TITLE
ignore AccessDeniedException completely

### DIFF
--- a/resources/organizations_accounts.go
+++ b/resources/organizations_accounts.go
@@ -84,7 +84,7 @@ func fetchOrganizationsAccounts(ctx context.Context, meta schema.ClientMeta, par
 			case "AWSOrganizationsNotInUseException", "AccessDeniedException":
 				// This is going to happen most probably due to account not being the root organizational account
 				// so it's better to ignore it completly as it happens basically on every account
-				// otherwise it screws up with dev experiance and with our tests
+				// otherwise it screws up with dev experience and with our tests
 				meta.Logger().Warn("account is probably not the root organization account https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html")
 				return nil
 			}

--- a/resources/organizations_accounts.go
+++ b/resources/organizations_accounts.go
@@ -86,7 +86,7 @@ func fetchOrganizationsAccounts(ctx context.Context, meta schema.ClientMeta, par
 				// This is going to happen most probably due to account not being the root organizational account
 				// so it's better to ignore it completly as it happens basically on every account
 				// otherwise it screws up with dev experiance and with our tests
-				log.Warn("account is most probabbly not the root organization account https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html")
+				log.Warn("account is most probably not the root organization account https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html")
 				return nil
 			}
 		}

--- a/resources/organizations_accounts.go
+++ b/resources/organizations_accounts.go
@@ -83,7 +83,7 @@ func fetchOrganizationsAccounts(ctx context.Context, meta schema.ClientMeta, par
 		if errors.As(err, &ae) {
 			switch ae.ErrorCode() {
 			case "AWSOrganizationsNotInUseException", "AccessDeniedException":
-				// This is going to happen most proabbly due to account not being the root organizational account
+				// This is going to happen most probably due to account not being the root organizational account
 				// so it's better to ignore it completly as it happens basically on every account
 				// otherwise it screws up with dev experiance and with our tests
 				log.Warn("account is most probabbly not the root organization account https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html")

--- a/resources/organizations_accounts.go
+++ b/resources/organizations_accounts.go
@@ -74,7 +74,6 @@ func OrganizationsAccounts() *schema.Table {
 // ====================================================================================================================
 func fetchOrganizationsAccounts(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan interface{}) error {
 	c := meta.(*client.Client)
-	log := meta.Logger()
 	svc := c.Services().Organizations
 	var input organizations.ListAccountsInput
 	for {
@@ -86,7 +85,7 @@ func fetchOrganizationsAccounts(ctx context.Context, meta schema.ClientMeta, par
 				// This is going to happen most probably due to account not being the root organizational account
 				// so it's better to ignore it completly as it happens basically on every account
 				// otherwise it screws up with dev experiance and with our tests
-				log.Warn("account is most probably not the root organization account https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html")
+				meta.Logger().Warn("account is probably not the root organization account https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html")
 				return nil
 			}
 		}


### PR DESCRIPTION
<!---
Thank you very much for your contributions!
--->

I suggest ignoring this completely until AWS will come up with a better way to detect if we are in a root account or not, otherwise it makes the following two issues (I know this was the original suggestion of @spangenberg but I missed this PR or didn't understand completely how the diag works ):

1) the user experience on correct permissions is not smooth
2) our ci tests might fail because of that


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:
More information about running the tests [here](../docs/contributing/e2e_tests.md)
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.


More information about running the tests [here](../docs/contributing/e2e_tests.md)
-->
```
$ make testName=TestAccXXX e2e-test-with-apply
...
```