### PR TITLE
Add test: MultiplexerPKMatch

### DIFF
--- a/resources/provider_test.go
+++ b/resources/provider_test.go
@@ -41,12 +41,15 @@ func awsTestHelper(t *testing.T, table *schema.Table, builder func(*testing.T, *
 }
 
 func TestMultiplexerPKMatch(t *testing.T) {
+	t.Parallel()
 	for res, table := range Provider().ResourceMap {
 		if table.Multiplex == nil {
 			continue
 		}
 
+		table := table
 		t.Run(res, func(t *testing.T) {
+			t.Parallel()
 			cfgRegions := []string{"us-east-1", "eu-west-1"}
 
 			c := client.NewAwsClient(logging.New(&hclog.LoggerOptions{
@@ -78,6 +81,10 @@ func TestMultiplexerPKMatch(t *testing.T) {
 			// Multiple accounts OR regions confirmed
 
 			for _, c := range table.PrimaryKeys() {
+				if c == "arn" { // ARN satisfies both account_id and region
+					delete(requiredPKs, "account_id")
+					delete(requiredPKs, "region")
+				}
 				delete(requiredPKs, c)
 			}
 

--- a/resources/provider_test.go
+++ b/resources/provider_test.go
@@ -9,6 +9,7 @@ import (
 	providertest "github.com/cloudquery/cq-provider-sdk/provider/testing"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestOptions struct {
@@ -37,4 +38,50 @@ func awsTestHelper(t *testing.T, table *schema.Table, builder func(*testing.T, *
 		},
 		SkipEmptyJsonB: options.SkipEmptyJsonB,
 	})
+}
+
+func TestMultiplexerPKMatch(t *testing.T) {
+	for res, table := range Provider().ResourceMap {
+		if table.Multiplex == nil {
+			continue
+		}
+
+		t.Run(res, func(t *testing.T) {
+			cfgRegions := []string{"us-east-1", "eu-west-1"}
+
+			c := client.NewAwsClient(logging.New(&hclog.LoggerOptions{
+				Level: hclog.Warn,
+			}), []client.Account{{ID: "test1"}, {ID: "test2"}}, cfgRegions)
+			for _, a := range c.Accounts {
+				for _, r := range cfgRegions {
+					c.ServicesManager.InitServicesForAccountAndRegion(a.AccountID, r, client.Services{})
+				}
+			}
+
+			multiClients := table.Multiplex(schema.ClientMeta(&c))
+
+			regions, accounts := make(map[string]struct{}), make(map[string]struct{})
+			for _, c := range multiClients {
+				cc := c.(*client.Client)
+				accounts[cc.AccountID], regions[cc.Region] = struct{}{}, struct{}{}
+			}
+			requiredPKs := make(map[string]struct{})
+			if len(accounts) > 1 {
+				requiredPKs["account_id"] = struct{}{}
+			}
+			if len(regions) > 1 {
+				requiredPKs["region"] = struct{}{}
+			}
+			if len(requiredPKs) == 0 {
+				return
+			}
+			// Multiple accounts OR regions confirmed
+
+			for _, c := range table.PrimaryKeys() {
+				delete(requiredPKs, c)
+			}
+
+			assert.Zero(t, len(requiredPKs), "Missing PKs: %+v", requiredPKs)
+		})
+	}
 }


### PR DESCRIPTION
Not sure if this is even valid, only issue so far is elasticsearch (which can have the same `id` under multiple regions...) but this is failing so many  resources.