### PR TITLE
Fix elasticsearch domains PK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this provider will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### :spider: Fixed
+* Fixed PK error with elasticsearch domains [#384](https://github.com/cloudquery/cq-provider-aws/pull/384).
+
 ## [v0.8.4] - 2021-12-23
 ###### SDK Version: 0.5.7
 

--- a/resources/provider/migrations/12_v0.8.5.down.sql
+++ b/resources/provider/migrations/12_v0.8.5.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS "aws_elasticsearch_domains" DROP CONSTRAINT IF EXISTS "aws_elasticsearch_domains_pk";
+
+ALTER TABLE "aws_elasticsearch_domains"
+    ADD CONSTRAINT "aws_elasticsearch_domains_pk"
+        PRIMARY KEY(account_id, id);

--- a/resources/provider/migrations/12_v0.8.5.up.sql
+++ b/resources/provider/migrations/12_v0.8.5.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS "aws_elasticsearch_domains" DROP CONSTRAINT IF EXISTS "aws_elasticsearch_domains_pk";
+
+ALTER TABLE "aws_elasticsearch_domains"
+    ADD CONSTRAINT "aws_elasticsearch_domains_pk"
+        PRIMARY KEY(account_id, id, region);

--- a/resources/provider/migrations/12_v0.8.5.up.sql
+++ b/resources/provider/migrations/12_v0.8.5.up.sql
@@ -2,4 +2,4 @@ ALTER TABLE IF EXISTS "aws_elasticsearch_domains" DROP CONSTRAINT IF EXISTS "aws
 
 ALTER TABLE "aws_elasticsearch_domains"
     ADD CONSTRAINT "aws_elasticsearch_domains_pk"
-        PRIMARY KEY(account_id, id, region);
+        PRIMARY KEY(account_id, region, id);

--- a/resources/services/elasticsearch/elasticsearch_domains.go
+++ b/resources/services/elasticsearch/elasticsearch_domains.go
@@ -18,7 +18,7 @@ func ElasticsearchDomains() *schema.Table {
 		Multiplex:    client.ServiceAccountRegionMultiplexer("es"),
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
 		DeleteFilter: client.DeleteAccountRegionFilter,
-		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
+		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id", "region"}},
 		Columns: []schema.Column{
 			{
 				Name:        "account_id",

--- a/resources/services/elasticsearch/elasticsearch_domains.go
+++ b/resources/services/elasticsearch/elasticsearch_domains.go
@@ -18,7 +18,7 @@ func ElasticsearchDomains() *schema.Table {
 		Multiplex:    client.ServiceAccountRegionMultiplexer("es"),
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
 		DeleteFilter: client.DeleteAccountRegionFilter,
-		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id", "region"}},
+		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
 		Columns: []schema.Column{
 			{
 				Name:        "account_id",


### PR DESCRIPTION
ElasticSearch domains [are unique](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/es/create-elasticsearch-domain.html) _per region_ but the PK was defined as `account_id, id`.

Manually tested in a "throwaway" AWS account.