### PR TITLE
WIP: Fix regions filtering overriding for each account

### DIFF
--- a/client/helpers.go
+++ b/client/helpers.go
@@ -89,6 +89,23 @@ func isSupportedServiceForRegion(service string, region string) bool {
 	return true
 }
 
+// isAllRegions return true if regions is empty which means fetch all regions
+// or ["*"]
+func isAllRegions(regions []string) bool {
+	return len(regions) == 0 || (len(regions) == 1 && regions[0] == "*")
+}
+
+// validateRegions will return an error for the following cases (cases might grow over time):
+// "*" is specified with aditional regions
+func validateRegions(regions []string) error {
+	for i, r := range regions {
+		if i != 0 && r == "*" {
+			return fmt.Errorf("region wildcard \"*\" is only supported in 0 index")
+		}
+	}
+	return nil
+}
+
 func IgnoreAccessDeniedServiceDisabled(err error) bool {
 	var ae smithy.APIError
 	if errors.As(err, &ae) {

--- a/client/multiplexers.go
+++ b/client/multiplexers.go
@@ -15,8 +15,8 @@ func ServiceAccountRegionMultiplexer(service string) func(meta schema.ClientMeta
 	return func(meta schema.ClientMeta) []schema.ClientMeta {
 		var l = make([]schema.ClientMeta, 0)
 		client := meta.(*Client)
-		for accountID := range client.ServicesManager.services {
-			for _, region := range client.regions {
+		for accountID, regionMap := range client.ServicesManager.services {
+			for region := range regionMap {
 				if !isSupportedServiceForRegion(service, region) {
 					meta.Logger().Trace("region is not supported for service", "service", service, "region", region)
 					continue
@@ -36,8 +36,8 @@ func ServiceAccountRegionNamespaceMultiplexer(service string) func(meta schema.C
 	return func(meta schema.ClientMeta) []schema.ClientMeta {
 		var l = make([]schema.ClientMeta, 0)
 		client := meta.(*Client)
-		for accountID := range client.ServicesManager.services {
-			for _, region := range client.regions {
+		for accountID, regionMap := range client.ServicesManager.services {
+			for region := range regionMap {
 				for _, ns := range AllNamespaces {
 					if !isSupportedServiceForRegion(service, region) {
 						meta.Logger().Trace("region is not supported for service", "service", service, "region", region)

--- a/client/testing.go
+++ b/client/testing.go
@@ -39,7 +39,7 @@ func AwsMockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.
 			Configure: func(logger hclog.Logger, i interface{}) (schema.ClientMeta, error) {
 				c := NewAwsClient(logging.New(&hclog.LoggerOptions{
 					Level: hclog.Warn,
-				}), accounts, []string{"us-east-1"})
+				}), accounts)
 				c.ServicesManager.InitServicesForAccountAndRegion("testAccount", "us-east-1", builder(t, ctrl))
 				return &c, nil
 			},


### PR DESCRIPTION
<!---
Thank you very much for your contributions!
--->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
- [ ] Closes #242
- [ ] Related #391 
- [ ] Added integration tests as described [here](https://docs.cloudquery.io/docs/developers/sdk/testing)

This is a continuation of https://github.com/cloudquery/cq-provider-aws/pull/391. 

As uncovered in #391 this [line](https://github.com/cloudquery/cq-provider-aws/blob/main/client/client.go#L382) of detecting which regions are enabled in a specific account is overriding all the accounts. Moreover we don't need the `regions` field on the [client](https://github.com/cloudquery/cq-provider-aws/blob/main/client/client.go#L192) level as this is incorrect and it should be only specified on the account level (even though we can have in the config).

Also, as noted in this [comment](https://github.com/cloudquery/cq-provider-aws/pull/391/files#r779065690) by @bbernays we don't need the list of regions at all, this also remove the burden of maintaining it.

I'll test it manually but also I think we might need some additional testing here as it's a bit hard to verify manually all the edge-cases.
