### PR TITLE
fix: E2E tests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -351,8 +351,7 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 
 	if len(awsConfig.Accounts) == 0 {
 		awsConfig.Accounts = append(awsConfig.Accounts, Account{
-			ID:           defaultVar,
-			LocalProfile: defaultVar,
+			ID: defaultVar,
 		})
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -201,7 +201,11 @@ func Test_Configure(t *testing.T) {
 	if _, err := f.Write(data); err != nil {
 		log.Fatal(err)
 	}
+
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", f.Name())
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_SESSION_TOKEN")
 
 	tests := []struct {
 		stsclient    func(t *testing.T) AssumeRoleAPIClient


### PR DESCRIPTION
<!---
Thank you very much for your contributions!
--->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
- [ ] Relates OR Closes #0000
- [ ] Added integration tests as described [here](https://docs.cloudquery.io/docs/developers/sdk/testing)

Output from integration tests:
More information about running the tests [here](../docs/contributing/e2e_tests.md)

```
cq-provider-aws % go test -tags=integration ./...                
?       github.com/cloudquery/cq-provider-aws   [no test files]
ok      github.com/cloudquery/cq-provider-aws/client    1.495s?       github.com/cloudquery/cq-provider-aws/client/mocks      [no test files]?       github.com/cloudquery/cq-provider-aws/docs      [no test files]?       github.com/cloudquery/cq-provider-aws/resources/forks   [no test files]?       github.com/cloudquery/cq-provider-aws/resources/forks/apigatewayv2      [no test files]?       github.com/cloudquery/cq-provider-aws/resources/provider        [no test files]ok      github.com/cloudquery/cq-provider-aws/resources/services/accessanalyzer 5.740s
?       github.com/cloudquery/cq-provider-aws/resources/services/acm    [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/apigateway     6.352s
ok      github.com/cloudquery/cq-provider-aws/resources/services/apigatewayv2   19.037s
?       github.com/cloudquery/cq-provider-aws/resources/services/applicationautoscaling [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/autoscaling    3.216s
ok      github.com/cloudquery/cq-provider-aws/resources/services/cloudfront     2.247s
ok      github.com/cloudquery/cq-provider-aws/resources/services/cloudtrail     6.247s
ok      github.com/cloudquery/cq-provider-aws/resources/services/cloudwatch     4.395s
ok      github.com/cloudquery/cq-provider-aws/resources/services/cloudwatchlogs 4.011s
ok      github.com/cloudquery/cq-provider-aws/resources/services/codebuild      3.113s
ok      github.com/cloudquery/cq-provider-aws/resources/services/cognito        3.464s
ok      github.com/cloudquery/cq-provider-aws/resources/services/config 2.918s
?       github.com/cloudquery/cq-provider-aws/resources/services/dax    [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/directconnect  3.870s
ok      github.com/cloudquery/cq-provider-aws/resources/services/dms    3.361s
?       github.com/cloudquery/cq-provider-aws/resources/services/dynamodb       [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/ec2    8.796s
ok      github.com/cloudquery/cq-provider-aws/resources/services/ecr    5.617s
ok      github.com/cloudquery/cq-provider-aws/resources/services/ecs    5.084s
ok      github.com/cloudquery/cq-provider-aws/resources/services/efs    3.878s
ok      github.com/cloudquery/cq-provider-aws/resources/services/eks    4.054s
ok      github.com/cloudquery/cq-provider-aws/resources/services/elasticbeanstalk       3.082s
ok      github.com/cloudquery/cq-provider-aws/resources/services/elasticsearch  2.613s
ok      github.com/cloudquery/cq-provider-aws/resources/services/elbv1  2.839s
ok      github.com/cloudquery/cq-provider-aws/resources/services/elbv2  2.918s
ok      github.com/cloudquery/cq-provider-aws/resources/services/emr    3.142s
ok      github.com/cloudquery/cq-provider-aws/resources/services/fsx    3.356s
ok      github.com/cloudquery/cq-provider-aws/resources/services/guardduty      2.475s
ok      github.com/cloudquery/cq-provider-aws/resources/services/iam    10.001s
?       github.com/cloudquery/cq-provider-aws/resources/services/iot    [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/kms    4.796s
ok      github.com/cloudquery/cq-provider-aws/resources/services/lambda 5.749s
ok      github.com/cloudquery/cq-provider-aws/resources/services/mq     2.806s
?       github.com/cloudquery/cq-provider-aws/resources/services/organizations  [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/rds    5.632s
ok      github.com/cloudquery/cq-provider-aws/resources/services/redshift       2.637s
ok      github.com/cloudquery/cq-provider-aws/resources/services/route53        3.335s
ok      github.com/cloudquery/cq-provider-aws/resources/services/s3     10.805s
ok      github.com/cloudquery/cq-provider-aws/resources/services/sagemaker      3.124s
ok      github.com/cloudquery/cq-provider-aws/resources/services/secretsmanager 2.587s
?       github.com/cloudquery/cq-provider-aws/resources/services/sns    [no test files]
ok      github.com/cloudquery/cq-provider-aws/resources/services/sqs    3.302s
ok      github.com/cloudquery/cq-provider-aws/resources/services/ssm    2.810s
ok      github.com/cloudquery/cq-provider-aws/resources/services/waf    1.955s
ok      github.com/cloudquery/cq-provider-aws/resources/services/wafv2  7.495s
?       github.com/cloudquery/cq-provider-aws/tools/endpoints   [no test files]
```