### PR TITLE
fix: Sagemaker panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,3 +146,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/cloudquery/cq-provider-sdk v0.7.0-alpha2 => ../cq-provider-sdk

--- a/go.mod
+++ b/go.mod
@@ -146,5 +146,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/cloudquery/cq-provider-sdk v0.7.0-alpha2 => ../cq-provider-sdk

--- a/resources/services/sagemaker/training_jobs.go
+++ b/resources/services/sagemaker/training_jobs.go
@@ -601,7 +601,7 @@ func fetchSagemakerTrainingJobAlgorithmSpecifications(_ context.Context, _ schem
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil || r.AlgorithmSpecification == nil {
+	} else if r.AlgorithmSpecification == nil {
 		return nil
 	}
 	res <- r.AlgorithmSpecification
@@ -611,7 +611,7 @@ func resolveSagemakerTrainingJobAlgorithmSpecificationsMetricDefinitions(_ conte
 	r, ok := resource.Item.(*types.AlgorithmSpecification)
 	if !ok {
 		return fmt.Errorf("expected AlgorithmSpecification but got %T", resource.Item)
-	} else if r == nil {
+	} else if len(r.MetricDefinitions) == 0 {
 		return nil
 	}
 	var metricDefinitions = make([]map[string]interface{}, len(r.MetricDefinitions))
@@ -632,7 +632,7 @@ func fetchSagemakerTrainingJobDebugHookConfigs(_ context.Context, _ schema.Clien
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil || r.DebugHookConfig == nil {
+	} else if r.DebugHookConfig == nil {
 		return nil
 	}
 	res <- r.DebugHookConfig
@@ -642,7 +642,7 @@ func resolveSagemakerTrainingJobDebugHookConfigsCollectionConfigurations(_ conte
 	r, ok := resource.Item.(*types.DebugHookConfig)
 	if !ok {
 		return fmt.Errorf("expected DebugHookConfig but got %T", resource.Item)
-	} else if r == nil {
+	} else if len(r.CollectionConfigurations) == 0 {
 		return nil
 	}
 	var collectionConfigurations = make([]map[string]interface{}, len(r.CollectionConfigurations))
@@ -663,8 +663,6 @@ func fetchSagemakerTrainingJobDebugRuleConfigurations(_ context.Context, _ schem
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
-		return nil
 	}
 	res <- r.DebugRuleConfigurations
 	return nil
@@ -673,8 +671,6 @@ func fetchSagemakerTrainingJobDebugRuleEvaluationStatuses(_ context.Context, _ s
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
-		return nil
 	}
 	res <- r.DebugRuleEvaluationStatuses
 	return nil
@@ -683,8 +679,6 @@ func fetchSagemakerTrainingJobInputDataConfigs(_ context.Context, _ schema.Clien
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
-		return nil
 	}
 	res <- r.InputDataConfig
 	return nil
@@ -693,8 +687,6 @@ func fetchSagemakerTrainingJobProfilerRuleConfigurations(_ context.Context, _ sc
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
-		return nil
 	}
 	res <- r.ProfilerRuleConfigurations
 	return nil
@@ -703,8 +695,6 @@ func fetchSagemakerTrainingJobProfilerRuleEvaluationStatuses(_ context.Context, 
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
-		return nil
 	}
 	res <- r.ProfilerRuleEvaluationStatuses
 	return nil
@@ -713,7 +703,7 @@ func resolveSagemakerTrainingJobCheckpointConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.CheckpointConfig == nil {
+	} else if r.CheckpointConfig == nil {
 		return nil
 	}
 	checkpointConfig := map[string]interface{}{
@@ -726,7 +716,7 @@ func resolveSagemakerTrainingJobExperimentConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.ExperimentConfig == nil {
+	} else if r.ExperimentConfig == nil {
 		return nil
 	}
 	experimentConfig := map[string]interface{}{
@@ -740,7 +730,7 @@ func resolveSagemakerTrainingJobModelArtifacts(__ context.Context, _ schema.Clie
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.ModelArtifacts == nil {
+	} else if r.ModelArtifacts == nil {
 		return nil
 	}
 	modelArtifacts := map[string]interface{}{
@@ -765,7 +755,7 @@ func resolveSagemakerTrainingJobProfilerConfig(_ context.Context, _ schema.Clien
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.ProfilerConfig == nil {
+	} else if r.ProfilerConfig == nil {
 		return nil
 	}
 	profilerConfig := map[string]interface{}{
@@ -779,7 +769,7 @@ func resolveSagemakerTrainingJobResourceConfig(_ context.Context, _ schema.Clien
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.ResourceConfig == nil {
+	} else if r.ResourceConfig == nil {
 		return nil
 	}
 	resourceConfig := map[string]interface{}{
@@ -794,7 +784,7 @@ func resolveSagemakerTrainingJobStoppingCondition(_ context.Context, _ schema.Cl
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.StoppingCondition == nil {
+	} else if r.StoppingCondition == nil {
 		return nil
 	}
 	stoppingCondition := map[string]interface{}{
@@ -807,7 +797,7 @@ func resolveSagemakerTrainingJobTensorBoardOutputConfig(_ context.Context, _ sch
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.TensorBoardOutputConfig == nil {
+	} else if r.TensorBoardOutputConfig == nil {
 		return nil
 	}
 	tensorBoardOutputConfig := map[string]interface{}{
@@ -820,7 +810,7 @@ func resolveSagemakerTrainingJobVpcConfig(_ context.Context, _ schema.ClientMeta
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.VpcConfig == nil {
+	} else if r.VpcConfig == nil {
 		return nil
 	}
 	vpcConfig := map[string]interface{}{
@@ -860,7 +850,7 @@ func resolveSagemakerTrainingJobSecondaryStatusTransitions(_ context.Context, _ 
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
-	} else if r == nil {
+	} else if len(r.SecondaryStatusTransitions) == 0 {
 		return nil
 	}
 
@@ -884,7 +874,7 @@ func resolveSagemakerTrainingJobFinalMetricDataList(_ context.Context, _ schema.
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
-	} else if r == nil {
+	} else if len(r.FinalMetricDataList) == 0 {
 		return nil
 	}
 

--- a/resources/services/sagemaker/training_jobs.go
+++ b/resources/services/sagemaker/training_jobs.go
@@ -601,7 +601,8 @@ func fetchSagemakerTrainingJobAlgorithmSpecifications(_ context.Context, _ schem
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r.AlgorithmSpecification == nil {
+	}
+	if r.AlgorithmSpecification == nil {
 		return nil
 	}
 	res <- r.AlgorithmSpecification
@@ -611,9 +612,11 @@ func resolveSagemakerTrainingJobAlgorithmSpecificationsMetricDefinitions(_ conte
 	r, ok := resource.Item.(*types.AlgorithmSpecification)
 	if !ok {
 		return fmt.Errorf("expected AlgorithmSpecification but got %T", resource.Item)
-	} else if len(r.MetricDefinitions) == 0 {
+	}
+	if len(r.MetricDefinitions) == 0 {
 		return nil
 	}
+
 	var metricDefinitions = make([]map[string]interface{}, len(r.MetricDefinitions))
 
 	for i, metric := range r.MetricDefinitions {
@@ -632,9 +635,11 @@ func fetchSagemakerTrainingJobDebugHookConfigs(_ context.Context, _ schema.Clien
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r.DebugHookConfig == nil {
+	}
+	if r.DebugHookConfig == nil {
 		return nil
 	}
+
 	res <- r.DebugHookConfig
 	return nil
 }
@@ -642,9 +647,11 @@ func resolveSagemakerTrainingJobDebugHookConfigsCollectionConfigurations(_ conte
 	r, ok := resource.Item.(*types.DebugHookConfig)
 	if !ok {
 		return fmt.Errorf("expected DebugHookConfig but got %T", resource.Item)
-	} else if len(r.CollectionConfigurations) == 0 {
+	}
+	if len(r.CollectionConfigurations) == 0 {
 		return nil
 	}
+
 	var collectionConfigurations = make([]map[string]interface{}, len(r.CollectionConfigurations))
 
 	for i, config := range r.CollectionConfigurations {
@@ -703,9 +710,11 @@ func resolveSagemakerTrainingJobCheckpointConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.CheckpointConfig == nil {
+	}
+	if r.CheckpointConfig == nil {
 		return nil
 	}
+
 	checkpointConfig := map[string]interface{}{
 		"s3_uri":     aws.ToString(r.CheckpointConfig.S3Uri),
 		"local_path": aws.ToString(r.CheckpointConfig.LocalPath),
@@ -719,6 +728,7 @@ func resolveSagemakerTrainingJobExperimentConfig(_ context.Context, _ schema.Cli
 	} else if r.ExperimentConfig == nil {
 		return nil
 	}
+
 	experimentConfig := map[string]interface{}{
 		"experiment_name":              aws.ToString(r.ExperimentConfig.ExperimentName),
 		"trial_component_display_name": aws.ToString(r.ExperimentConfig.TrialComponentDisplayName),
@@ -730,9 +740,11 @@ func resolveSagemakerTrainingJobModelArtifacts(__ context.Context, _ schema.Clie
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.ModelArtifacts == nil {
+	}
+	if r.ModelArtifacts == nil {
 		return nil
 	}
+
 	modelArtifacts := map[string]interface{}{
 		"s3_model_artifacts": aws.ToString(r.ModelArtifacts.S3ModelArtifacts),
 	}
@@ -742,9 +754,11 @@ func resolveSagemakerTrainingJobOutputDataConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil || r.OutputDataConfig == nil {
+	}
+	if r.OutputDataConfig == nil {
 		return nil
 	}
+
 	outputDataConfig := map[string]interface{}{
 		"s3_output_path": aws.ToString(r.OutputDataConfig.S3OutputPath),
 		"kms_key_id":     aws.ToString(r.OutputDataConfig.KmsKeyId),
@@ -755,9 +769,11 @@ func resolveSagemakerTrainingJobProfilerConfig(_ context.Context, _ schema.Clien
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.ProfilerConfig == nil {
+	}
+	if r.ProfilerConfig == nil {
 		return nil
 	}
+
 	profilerConfig := map[string]interface{}{
 		"s3_output_path":           aws.ToString(r.ProfilerConfig.S3OutputPath),
 		"profiling_interval_in_ms": aws.ToInt64(r.ProfilerConfig.ProfilingIntervalInMilliseconds),
@@ -769,9 +785,11 @@ func resolveSagemakerTrainingJobResourceConfig(_ context.Context, _ schema.Clien
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.ResourceConfig == nil {
+	}
+	if r.ResourceConfig == nil {
 		return nil
 	}
+
 	resourceConfig := map[string]interface{}{
 		"instance_count":    r.ResourceConfig.InstanceCount,
 		"instance_type":     r.ResourceConfig.InstanceType,
@@ -784,9 +802,11 @@ func resolveSagemakerTrainingJobStoppingCondition(_ context.Context, _ schema.Cl
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.StoppingCondition == nil {
+	}
+	if r.StoppingCondition == nil {
 		return nil
 	}
+
 	stoppingCondition := map[string]interface{}{
 		"max_runtime_in_seconds":   r.StoppingCondition.MaxRuntimeInSeconds,
 		"max_wait_time_in_seconds": r.StoppingCondition.MaxWaitTimeInSeconds,
@@ -797,9 +817,11 @@ func resolveSagemakerTrainingJobTensorBoardOutputConfig(_ context.Context, _ sch
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.TensorBoardOutputConfig == nil {
+	}
+	if r.TensorBoardOutputConfig == nil {
 		return nil
 	}
+
 	tensorBoardOutputConfig := map[string]interface{}{
 		"s3_output_path": r.TensorBoardOutputConfig.S3OutputPath,
 		"local_path":     r.TensorBoardOutputConfig.LocalPath,
@@ -810,9 +832,11 @@ func resolveSagemakerTrainingJobVpcConfig(_ context.Context, _ schema.ClientMeta
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.VpcConfig == nil {
+	}
+	if r.VpcConfig == nil {
 		return nil
 	}
+
 	vpcConfig := map[string]interface{}{
 		"subnets":            r.VpcConfig.Subnets,
 		"security_group_ids": r.VpcConfig.SecurityGroupIds,
@@ -823,7 +847,8 @@ func resolveSagemakerTrainingJobTags(ctx context.Context, meta schema.ClientMeta
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r == nil {
+	}
+	if r == nil {
 		return nil
 	}
 
@@ -850,7 +875,8 @@ func resolveSagemakerTrainingJobSecondaryStatusTransitions(_ context.Context, _ 
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
-	} else if len(r.SecondaryStatusTransitions) == 0 {
+	}
+	if len(r.SecondaryStatusTransitions) == 0 {
 		return nil
 	}
 
@@ -874,7 +900,8 @@ func resolveSagemakerTrainingJobFinalMetricDataList(_ context.Context, _ schema.
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
-	} else if len(r.FinalMetricDataList) == 0 {
+	}
+	if len(r.FinalMetricDataList) == 0 {
 		return nil
 	}
 

--- a/resources/services/sagemaker/training_jobs.go
+++ b/resources/services/sagemaker/training_jobs.go
@@ -601,7 +601,7 @@ func fetchSagemakerTrainingJobAlgorithmSpecifications(_ context.Context, _ schem
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
+	} else if r == nil || r.AlgorithmSpecification == nil {
 		return nil
 	}
 	res <- r.AlgorithmSpecification
@@ -632,7 +632,7 @@ func fetchSagemakerTrainingJobDebugHookConfigs(_ context.Context, _ schema.Clien
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	} else if r == nil {
+	} else if r == nil || r.DebugHookConfig == nil {
 		return nil
 	}
 	res <- r.DebugHookConfig
@@ -794,8 +794,7 @@ func resolveSagemakerTrainingJobStoppingCondition(_ context.Context, _ schema.Cl
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.StoppingCondition == nil {
+	} else if r == nil || r.StoppingCondition == nil {
 		return nil
 	}
 	stoppingCondition := map[string]interface{}{

--- a/resources/services/sagemaker/training_jobs.go
+++ b/resources/services/sagemaker/training_jobs.go
@@ -601,6 +601,8 @@ func fetchSagemakerTrainingJobAlgorithmSpecifications(_ context.Context, _ schem
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.AlgorithmSpecification
 	return nil
@@ -609,6 +611,8 @@ func resolveSagemakerTrainingJobAlgorithmSpecificationsMetricDefinitions(_ conte
 	r, ok := resource.Item.(*types.AlgorithmSpecification)
 	if !ok {
 		return fmt.Errorf("expected AlgorithmSpecification but got %T", resource.Item)
+	} else if r == nil {
+		return nil
 	}
 	var metricDefinitions = make([]map[string]interface{}, len(r.MetricDefinitions))
 
@@ -628,6 +632,8 @@ func fetchSagemakerTrainingJobDebugHookConfigs(_ context.Context, _ schema.Clien
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.DebugHookConfig
 	return nil
@@ -636,6 +642,8 @@ func resolveSagemakerTrainingJobDebugHookConfigsCollectionConfigurations(_ conte
 	r, ok := resource.Item.(*types.DebugHookConfig)
 	if !ok {
 		return fmt.Errorf("expected DebugHookConfig but got %T", resource.Item)
+	} else if r == nil {
+		return nil
 	}
 	var collectionConfigurations = make([]map[string]interface{}, len(r.CollectionConfigurations))
 
@@ -655,6 +663,8 @@ func fetchSagemakerTrainingJobDebugRuleConfigurations(_ context.Context, _ schem
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.DebugRuleConfigurations
 	return nil
@@ -663,6 +673,8 @@ func fetchSagemakerTrainingJobDebugRuleEvaluationStatuses(_ context.Context, _ s
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.DebugRuleEvaluationStatuses
 	return nil
@@ -671,6 +683,8 @@ func fetchSagemakerTrainingJobInputDataConfigs(_ context.Context, _ schema.Clien
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.InputDataConfig
 	return nil
@@ -679,6 +693,8 @@ func fetchSagemakerTrainingJobProfilerRuleConfigurations(_ context.Context, _ sc
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.ProfilerRuleConfigurations
 	return nil
@@ -687,6 +703,8 @@ func fetchSagemakerTrainingJobProfilerRuleEvaluationStatuses(_ context.Context, 
 	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
+	} else if r == nil {
+		return nil
 	}
 	res <- r.ProfilerRuleEvaluationStatuses
 	return nil
@@ -695,8 +713,7 @@ func resolveSagemakerTrainingJobCheckpointConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.CheckpointConfig == nil {
+	} else if r == nil || r.CheckpointConfig == nil {
 		return nil
 	}
 	checkpointConfig := map[string]interface{}{
@@ -709,8 +726,7 @@ func resolveSagemakerTrainingJobExperimentConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.ExperimentConfig == nil {
+	} else if r == nil || r.ExperimentConfig == nil {
 		return nil
 	}
 	experimentConfig := map[string]interface{}{
@@ -724,8 +740,7 @@ func resolveSagemakerTrainingJobModelArtifacts(__ context.Context, _ schema.Clie
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.ModelArtifacts == nil {
+	} else if r == nil || r.ModelArtifacts == nil {
 		return nil
 	}
 	modelArtifacts := map[string]interface{}{
@@ -737,8 +752,7 @@ func resolveSagemakerTrainingJobOutputDataConfig(_ context.Context, _ schema.Cli
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.OutputDataConfig == nil {
+	} else if r == nil || r.OutputDataConfig == nil {
 		return nil
 	}
 	outputDataConfig := map[string]interface{}{
@@ -751,8 +765,7 @@ func resolveSagemakerTrainingJobProfilerConfig(_ context.Context, _ schema.Clien
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.ProfilerConfig == nil {
+	} else if r == nil || r.ProfilerConfig == nil {
 		return nil
 	}
 	profilerConfig := map[string]interface{}{
@@ -766,8 +779,7 @@ func resolveSagemakerTrainingJobResourceConfig(_ context.Context, _ schema.Clien
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.ResourceConfig == nil {
+	} else if r == nil || r.ResourceConfig == nil {
 		return nil
 	}
 	resourceConfig := map[string]interface{}{
@@ -796,8 +808,7 @@ func resolveSagemakerTrainingJobTensorBoardOutputConfig(_ context.Context, _ sch
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.TensorBoardOutputConfig == nil {
+	} else if r == nil || r.TensorBoardOutputConfig == nil {
 		return nil
 	}
 	tensorBoardOutputConfig := map[string]interface{}{
@@ -810,8 +821,7 @@ func resolveSagemakerTrainingJobVpcConfig(_ context.Context, _ schema.ClientMeta
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
-	if r.VpcConfig == nil {
+	} else if r == nil || r.VpcConfig == nil {
 		return nil
 	}
 	vpcConfig := map[string]interface{}{
@@ -822,9 +832,10 @@ func resolveSagemakerTrainingJobVpcConfig(_ context.Context, _ schema.ClientMeta
 }
 func resolveSagemakerTrainingJobTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, _ schema.Column) error {
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-
 	if !ok {
 		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
+	} else if r == nil {
+		return nil
 	}
 
 	c := meta.(*client.Client)
@@ -848,10 +859,12 @@ func resolveSagemakerTrainingJobTags(ctx context.Context, meta schema.ClientMeta
 }
 func resolveSagemakerTrainingJobSecondaryStatusTransitions(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-
 	if !ok {
 		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
+	} else if r == nil {
+		return nil
 	}
+
 	var secondaryStatusTransitions = make([]map[string]interface{}, len(r.SecondaryStatusTransitions))
 
 	for i, status := range r.SecondaryStatusTransitions {
@@ -870,12 +883,13 @@ func resolveSagemakerTrainingJobSecondaryStatusTransitions(_ context.Context, _ 
 }
 func resolveSagemakerTrainingJobFinalMetricDataList(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-
 	if !ok {
 		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
+	} else if r == nil {
+		return nil
 	}
-	var finalMetricDataList = make([]map[string]interface{}, len(r.FinalMetricDataList))
 
+	var finalMetricDataList = make([]map[string]interface{}, len(r.FinalMetricDataList))
 	for i, config := range r.FinalMetricDataList {
 		finalMetricDataList[i] = map[string]interface{}{
 			"metric_name": config.MetricName,


### PR DESCRIPTION
It was failing in [resolveSagemakerTrainingJobDebugHookConfigsCollectionConfigurations](https://github.com/cloudquery/cq-provider-aws/blob/c6d832b/resources/services/sagemaker/training_jobs.go#L640) but I went overboard with the nil checks.