### PR TITLE
feat: Remove PII

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -116,7 +116,8 @@ func isCodeThrottle(code string) bool {
 }
 
 var (
-	requestIdRegex = regexp.MustCompile(`\sRequestID: [0-9a-f-]+`)
+	requestIdRegex = regexp.MustCompile(`\sRequestID: [A-Za-z0-9-]+`)
+	hostIdRegex    = regexp.MustCompile(`\sHostID: [A-Za-z0-9+/_=-]+`)
 	arnIdRegex     = regexp.MustCompile(`\sarn:aws[A-Za-z0-9-]*:.+?\s`)
 )
 
@@ -125,6 +126,7 @@ func removePII(aa []Account, msg string) string {
 		msg = strings.ReplaceAll(msg, " AccountID "+aa[i].ID, " AccountID xxxx")
 	}
 	msg = requestIdRegex.ReplaceAllString(msg, " RequestID: xxxx")
+	msg = hostIdRegex.ReplaceAllString(msg, " HostID: xxxx")
 	msg = arnIdRegex.ReplaceAllString(msg, " arn:xxxx ")
 	msg = accountObfusactor(aa, msg)
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -8,48 +8,75 @@ import (
 
 	"github.com/aws/smithy-go"
 
+	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
-	"github.com/cloudquery/cq-provider-sdk/provider/schema/diag"
 )
 
-func ErrorClassifier(meta schema.ClientMeta, resourceName string, err error) []diag.Diagnostic {
+func ErrorClassifier(meta schema.ClientMeta, resourceName string, err error) diag.Diagnostics {
 	client := meta.(*Client)
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.ErrorCode() {
 		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId":
-			return []diag.Diagnostic{
-				diag.FromError(err, diag.WARNING, diag.ACCESS, resourceName, ParseSummaryMessage(client.Accounts, err, ae), errorCodeDescriptions[ae.ErrorCode()]),
+			return diag.Diagnostics{
+				RedactError(client.Accounts, diag.NewBaseError(err, diag.WARNING, diag.ACCESS, resourceName, ParseSummaryMessage(err, ae), errorCodeDescriptions[ae.ErrorCode()])),
 			}
 		case "InvalidAction":
-			return []diag.Diagnostic{
-				diag.FromError(err, diag.IGNORE, diag.RESOLVING, resourceName, ParseSummaryMessage(client.Accounts, err, ae),
-					"The action is invalid for the service."),
+			return diag.Diagnostics{
+				RedactError(client.Accounts, diag.NewBaseError(err, diag.IGNORE, diag.RESOLVING, resourceName, ParseSummaryMessage(err, ae),
+					"The action is invalid for the service.")),
 			}
 		}
 	}
 	if IsErrorThrottle(err) {
-		return []diag.Diagnostic{
-			diag.FromError(err, diag.WARNING, diag.THROTTLE, resourceName, ParseSummaryMessage(client.Accounts, err, ae),
-				"CloudQuery AWS provider has been throttled, increase max_retries/retry_timeout in provider configuration."),
+		return diag.Diagnostics{
+			RedactError(client.Accounts, diag.NewBaseError(err, diag.WARNING, diag.THROTTLE, resourceName, ParseSummaryMessage(err, ae),
+				"CloudQuery AWS provider has been throttled, increase max_retries/retry_timeout in provider configuration.")),
 		}
 	}
 
 	// Take over from SDK and always return diagnostics, redacting PII
-	return []diag.Diagnostic{
-		diag.FromError(err, diag.ERROR, diag.RESOLVING, resourceName, removePII(client.Accounts, err.Error()), ""),
+	return diag.Diagnostics{
+		RedactError(client.Accounts, diag.NewBaseError(err, diag.ERROR, diag.RESOLVING, resourceName, err.Error(), "")),
 	}
 }
 
-func ParseSummaryMessage(aa []Account, err error, apiErr smithy.APIError) string {
+func ParseSummaryMessage(err error, apiErr smithy.APIError) string {
 	for {
 		if op, ok := err.(*smithy.OperationError); ok {
-			return fmt.Sprintf("%s: %s - %s", op.Service(), op.Operation(), removePII(aa, apiErr.ErrorMessage()))
+			return fmt.Sprintf("%s: %s - %s", op.Service(), op.Operation(), apiErr.ErrorMessage())
 		}
 		if err = errors.Unwrap(err); err == nil {
-			return removePII(aa, apiErr.ErrorMessage())
+			return apiErr.ErrorMessage()
 		}
 	}
+}
+
+// RedactedDiagnostic contains both original and redacted versions of a diagnostic
+type RedactedDiagnostic struct {
+	diag.Diagnostic
+	redacted diag.Diagnostic
+}
+
+// RedactError redacts a given diagnostic and returns a RedactedDiagnostic containing both original and redacted versions
+func RedactError(aa []Account, e *diag.BaseError) *RedactedDiagnostic {
+	r := diag.NewBaseError(
+		errors.New(removePII(aa, e.Error())),
+		e.Severity(),
+		e.Type(),
+		e.Description().Resource,
+		removePII(aa, e.Description().Summary),
+		removePII(aa, e.Description().Detail),
+	)
+	return &RedactedDiagnostic{
+		Diagnostic: e,
+		redacted:   r,
+	}
+}
+
+// Redacted returns the redacted diagnostic contained within
+func (r *RedactedDiagnostic) Redacted() diag.Diagnostic {
+	return r.redacted
 }
 
 // IsErrorThrottle returns whether the error is to be throttled based on its code.
@@ -89,15 +116,15 @@ func isCodeThrottle(code string) bool {
 }
 
 var (
-	requestIdRegex = regexp.MustCompile(`RequestID: [0-9a-f-]+`)
-	arnIdRegex     = regexp.MustCompile(`\sarn:aws:.+?\s`)
+	requestIdRegex = regexp.MustCompile(`\sRequestID: [0-9a-f-]+`)
+	arnIdRegex     = regexp.MustCompile(`\sarn:aws[A-Za-z0-9-]*:.+?\s`)
 )
 
 func removePII(aa []Account, msg string) string {
 	for i := range aa {
 		msg = strings.ReplaceAll(msg, " AccountID "+aa[i].ID, " AccountID xxxx")
 	}
-	msg = requestIdRegex.ReplaceAllString(msg, "RequestID: xxxx")
+	msg = requestIdRegex.ReplaceAllString(msg, " RequestID: xxxx")
 	msg = arnIdRegex.ReplaceAllString(msg, " arn:xxxx ")
 	msg = accountObfusactor(aa, msg)
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -52,14 +52,8 @@ func ParseSummaryMessage(err error, apiErr smithy.APIError) string {
 	}
 }
 
-// RedactedDiagnostic contains both original and redacted versions of a diagnostic
-type RedactedDiagnostic struct {
-	diag.Diagnostic
-	redacted diag.Diagnostic
-}
-
 // RedactError redacts a given diagnostic and returns a RedactedDiagnostic containing both original and redacted versions
-func RedactError(aa []Account, e *diag.BaseError) *RedactedDiagnostic {
+func RedactError(aa []Account, e *diag.BaseError) diag.Diagnostic {
 	r := diag.NewBaseError(
 		errors.New(removePII(aa, e.Error())),
 		e.Severity(),
@@ -68,15 +62,7 @@ func RedactError(aa []Account, e *diag.BaseError) *RedactedDiagnostic {
 		removePII(aa, e.Description().Summary),
 		removePII(aa, e.Description().Detail),
 	)
-	return &RedactedDiagnostic{
-		Diagnostic: e,
-		redacted:   r,
-	}
-}
-
-// Redacted returns the redacted diagnostic contained within
-func (r *RedactedDiagnostic) Redacted() diag.Diagnostic {
-	return r.redacted
+	return diag.NewRedactedDiagnostic(e, r)
 }
 
 // IsErrorThrottle returns whether the error is to be throttled based on its code.

--- a/client/errors.go
+++ b/client/errors.go
@@ -43,8 +43,6 @@ func ErrorClassifier(meta schema.ClientMeta, resourceName string, err error) []d
 	return []diag.Diagnostic{
 		diag.FromError(err, diag.ERROR, diag.RESOLVING, resourceName, removePII(client.Accounts, err.Error()), ""),
 	}
-
-	return nil
 }
 
 func ParseSummaryMessage(aa []Account, err error, apiErr smithy.APIError) string {
@@ -95,7 +93,7 @@ func isCodeThrottle(code string) bool {
 }
 
 var (
-	requestIdRegex = regexp.MustCompile(`"RequestID: [0-9a-f-]+`)
+	requestIdRegex = regexp.MustCompile(`RequestID: [0-9a-f-]+`)
 	arnIdRegex     = regexp.MustCompile(`\sarn:aws:.+?\s`)
 )
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -17,11 +17,7 @@ func ErrorClassifier(meta schema.ClientMeta, resourceName string, err error) []d
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.ErrorCode() {
-		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError":
-			return []diag.Diagnostic{
-				diag.FromError(err, diag.WARNING, diag.ACCESS, resourceName, ParseSummaryMessage(client.Accounts, err, ae), errorCodeDescriptions[ae.ErrorCode()]),
-			}
-		case "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId":
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId":
 			return []diag.Diagnostic{
 				diag.FromError(err, diag.WARNING, diag.ACCESS, resourceName, ParseSummaryMessage(client.Accounts, err, ae), errorCodeDescriptions[ae.ErrorCode()]),
 			}

--- a/client/testing.go
+++ b/client/testing.go
@@ -13,10 +13,9 @@ import (
 )
 
 type TestOptions struct {
-	SkipEmptyJsonB bool
 }
 
-func AwsMockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.T, *gomock.Controller) Services, options TestOptions) {
+func AwsMockTestHelper(t *testing.T, table *schema.Table, builder func(*testing.T, *gomock.Controller) Services, _ TestOptions) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.9.1
 	github.com/bxcodec/faker v2.0.1+incompatible
-	github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220201130657-f76cf9294d61
+	github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220202132001-adcaec50c524
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/golang/mock v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.9.1
 	github.com/bxcodec/faker v2.0.1+incompatible
-	github.com/cloudquery/cq-provider-sdk v0.7.1
+	github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220201130657-f76cf9294d61
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/golang/mock v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.9.1
 	github.com/bxcodec/faker v2.0.1+incompatible
-	github.com/cloudquery/cq-provider-sdk v0.7.2
+	github.com/cloudquery/cq-provider-sdk v0.7.3
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/golang/mock v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.9.1
 	github.com/bxcodec/faker v2.0.1+incompatible
-	github.com/cloudquery/cq-provider-sdk v0.7.3
+	github.com/cloudquery/cq-provider-sdk v0.7.4
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/golang/mock v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.9.1
 	github.com/bxcodec/faker v2.0.1+incompatible
-	github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220202132001-adcaec50c524
+	github.com/cloudquery/cq-provider-sdk v0.7.2
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220202132001-adcaec50c524 h1:euIr1Tc2Y2npLB1fqKjyV/CiKoyyC9jZu5RIq1ZHsOA=
-github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220202132001-adcaec50c524/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
+github.com/cloudquery/cq-provider-sdk v0.7.2 h1:xGzTyJ5mFaZlabTXaA+lz6tyTsP1RoQ6JAnKG9c+qkg=
+github.com/cloudquery/cq-provider-sdk v0.7.2/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=

--- a/go.sum
+++ b/go.sum
@@ -318,12 +318,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.7.0 h1:PWERMQi7oUW0rHn/qKvf7cVcOhMB9xgx/i0W3hvoXOc=
-github.com/cloudquery/cq-provider-sdk v0.7.0/go.mod h1:T+ngRXzcjJ6otKDGkWnPrHTsZuHUe3KZKtyhSLcvHCs=
-github.com/cloudquery/cq-provider-sdk v0.7.1 h1:thKsjnBbeSAXO4nodYR9OFrdXVB243SXptlwp0RQ7ok=
-github.com/cloudquery/cq-provider-sdk v0.7.1/go.mod h1:T+ngRXzcjJ6otKDGkWnPrHTsZuHUe3KZKtyhSLcvHCs=
-github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220201130657-f76cf9294d61 h1:qDzbfdAeDPpuvW4hMutldQPw7RaZP3Z/L3WLvFcsRzE=
-github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220201130657-f76cf9294d61/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
+github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220202132001-adcaec50c524 h1:euIr1Tc2Y2npLB1fqKjyV/CiKoyyC9jZu5RIq1ZHsOA=
+github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220202132001-adcaec50c524/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.7.3 h1:4csxKT4C8Y31tdQi/9hJnH3T6lEvRrWQmxTCmeNF/M4=
-github.com/cloudquery/cq-provider-sdk v0.7.3/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
+github.com/cloudquery/cq-provider-sdk v0.7.4 h1:WPsoRB2O3zrHq2dKNFkm7g5ghZiAnp5YuMmKsWGtXCo=
+github.com/cloudquery/cq-provider-sdk v0.7.4/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/cloudquery/cq-provider-sdk v0.7.0 h1:PWERMQi7oUW0rHn/qKvf7cVcOhMB9xgx
 github.com/cloudquery/cq-provider-sdk v0.7.0/go.mod h1:T+ngRXzcjJ6otKDGkWnPrHTsZuHUe3KZKtyhSLcvHCs=
 github.com/cloudquery/cq-provider-sdk v0.7.1 h1:thKsjnBbeSAXO4nodYR9OFrdXVB243SXptlwp0RQ7ok=
 github.com/cloudquery/cq-provider-sdk v0.7.1/go.mod h1:T+ngRXzcjJ6otKDGkWnPrHTsZuHUe3KZKtyhSLcvHCs=
+github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220201130657-f76cf9294d61 h1:qDzbfdAeDPpuvW4hMutldQPw7RaZP3Z/L3WLvFcsRzE=
+github.com/cloudquery/cq-provider-sdk v0.7.2-0.20220201130657-f76cf9294d61/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.7.2 h1:xGzTyJ5mFaZlabTXaA+lz6tyTsP1RoQ6JAnKG9c+qkg=
-github.com/cloudquery/cq-provider-sdk v0.7.2/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
+github.com/cloudquery/cq-provider-sdk v0.7.3 h1:4csxKT4C8Y31tdQi/9hJnH3T6lEvRrWQmxTCmeNF/M4=
+github.com/cloudquery/cq-provider-sdk v0.7.3/go.mod h1:3XIx9D1zpx/IS2MQcbyBTxpvpUDI0xyBwPT3reKo/4k=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=

--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 
 	"github.com/cloudquery/cq-provider-aws/resources/services/iot"
-
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 

--- a/resources/services/redshift/mock_test.go
+++ b/resources/services/redshift/mock_test.go
@@ -63,7 +63,7 @@ func buildRedshiftSubnetGroupsMock(t *testing.T, ctrl *gomock.Controller) client
 }
 
 func TestRedshiftClusters(t *testing.T) {
-	client.AwsMockTestHelper(t, RedshiftClusters(), buildRedshiftClustersMock, client.TestOptions{SkipEmptyJsonB: true})
+	client.AwsMockTestHelper(t, RedshiftClusters(), buildRedshiftClustersMock, client.TestOptions{})
 }
 
 func TestRedshiftSubnetGroups(t *testing.T) {

--- a/resources/services/wafv2/rule_groups_mock_test.go
+++ b/resources/services/wafv2/rule_groups_mock_test.go
@@ -89,5 +89,5 @@ func buildWAFV2RuleGroupsMock(t *testing.T, ctrl *gomock.Controller) client.Serv
 }
 
 func TestWafV2RuleGroups(t *testing.T) {
-	client.AwsMockTestHelper(t, Wafv2RuleGroups(), buildWAFV2RuleGroupsMock, client.TestOptions{SkipEmptyJsonB: true})
+	client.AwsMockTestHelper(t, Wafv2RuleGroups(), buildWAFV2RuleGroupsMock, client.TestOptions{})
 }

--- a/resources/services/wafv2/web_acls_mock_test.go
+++ b/resources/services/wafv2/web_acls_mock_test.go
@@ -108,5 +108,5 @@ func buildWAFV2WebACLMock(t *testing.T, ctrl *gomock.Controller) client.Services
 }
 
 func TestWafV2WebACL(t *testing.T) {
-	client.AwsMockTestHelper(t, Wafv2WebAcls(), buildWAFV2WebACLMock, client.TestOptions{SkipEmptyJsonB: true})
+	client.AwsMockTestHelper(t, Wafv2WebAcls(), buildWAFV2WebACLMock, client.TestOptions{})
 }


### PR DESCRIPTION
I don't want to log/show pii-removed error messages to the end user (unless requested perhaps?) because that would be hard for debugging permissions and general setup. So maybe SDK `diag.Diagnostic` needs a new entry, a `redactedError`? Or just report multiple diag.Diagnostics, one normal and one redacted, and let the SDK choose which one to use when?