### PR TITLE
fix: Make RDS certificates 'Global'

### DIFF
--- a/resources/services/rds/certificates.go
+++ b/resources/services/rds/certificates.go
@@ -18,6 +18,7 @@ func RdsCertificates() *schema.Table {
 		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
+		Global:       true,
 		Columns: []schema.Column{
 			{
 				Name:     "account_id",


### PR DESCRIPTION
I think this is the ticket to fixing the rds certificate errors. [AWS doc](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Certificate.html)

The `certificate_identifier` is "rds-ca-2019" (which is in the `arn` along with region) and the `type` always seems to be `CA`... And there doesn't seem to be a way of uploading/creating a custom certificate in the UI.