### PR TITLE
docs: Remove 'labmda' from section about IAM auth

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ To authenticate CloudQuery with your AWS account you can use any of the followin
   - SDK defaults to `credentials` file under `.aws` folder that is placed in the home folder on your computer.
   - SDK defaults to `config` file under `.aws` folder that is placed in the home folder on your computer.
   - SDK is able to use SSO credentials stored in the `~/.aws/` directory
-- The SDK is able to use the IAM role associated with AWS Compute resources including (EC2 instances, Fargate and ECS containers, and Lambda Functions)
+- The SDK is able to use the IAM role associated with AWS Compute resources including (EC2 instances, Fargate and ECS containers).
 
 ## Configuration
 


### PR DESCRIPTION
Lambda runtime automatically inserts credentials into the environment variables.
See Ben's comment at https://github.com/cloudquery/docs/pull/82#discussion_r797861081

<!---
Thank you very much for your contributions!
--->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
- [ ] Relates OR Closes #0000
- [ ] Added integration tests as described [here](https://docs.cloudquery.io/docs/developers/sdk/testing)

Output from integration tests:
More information about running the tests [here](../docs/contributing/e2e_tests.md)

```
$ go test -tags=integration ./...

```