### PR TITLE
fix: EC2 Security Group Nested PK Issue

### DIFF
--- a/resources/services/ec2/security_groups.go
+++ b/resources/services/ec2/security_groups.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -308,7 +309,7 @@ func fetchEc2SecurityGroupIpPermissionUserIdGroupPairs(ctx context.Context, meta
 
 	for i := range securityGroupIpPermission.UserIdGroupPairs {
 		if securityGroupIpPermission.UserIdGroupPairs[i].UserId == nil {
-			securityGroupIpPermission.UserIdGroupPairs[i].UserId = aws.String("DELETED")
+			securityGroupIpPermission.UserIdGroupPairs[i].UserId = aws.String("DELETED-" + randomString(5))
 		}
 	}
 	res <- securityGroupIpPermission.UserIdGroupPairs
@@ -318,4 +319,14 @@ func fetchEc2SecurityGroupIpPermissionUserIdGroupPairs(ctx context.Context, meta
 type ipPermission struct {
 	types.IpPermission
 	PermissionType string
+}
+
+func randomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
 }

--- a/resources/services/ec2/security_groups.go
+++ b/resources/services/ec2/security_groups.go
@@ -305,6 +305,12 @@ func fetchEc2SecurityGroupIpPermissionUserIdGroupPairs(ctx context.Context, meta
 	if !ok {
 		return fmt.Errorf("not ec2 security group ip permission in user id group pair")
 	}
+
+	for i := range securityGroupIpPermission.UserIdGroupPairs {
+		if securityGroupIpPermission.UserIdGroupPairs[i].UserId == nil {
+			securityGroupIpPermission.UserIdGroupPairs[i].UserId = aws.String("DELETED")
+		}
+	}
 	res <- securityGroupIpPermission.UserIdGroupPairs
 	return nil
 }


### PR DESCRIPTION
According to the docs about `UserIdGroupPair.UserId`:

```
	// The ID of an Amazon Web Services account. For a referenced security group in
	// another VPC, the account ID of the referenced security group is returned in the
	// response. If the referenced security group is deleted, this value is not
	// returned.
```

So with this PR I am ensuring the value is never `null`