### PR TITLE
fix: DirectConnect Gateways are global

### DIFF
--- a/docs/tables/aws_directconnect_gateways.md
+++ b/docs/tables/aws_directconnect_gateways.md
@@ -5,7 +5,6 @@ Information about a Direct Connect gateway, which enables you to connect virtual
 | Name        | Type           | Description  |
 | ------------- | ------------- | -----  |
 |account_id|text|The AWS Account ID of the resource.|
-|region|text|The AWS Region of the resource.|
 |arn|text|The Amazon Resource Name (ARN) for the resource.|
 |amazon_side_asn|bigint|The autonomous system number (ASN) for the Amazon side of the connection.|
 |id|text|The ID of the Direct Connect gateway.|

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.5.1
 	github.com/aws/smithy-go v1.9.1
 	github.com/bxcodec/faker v2.0.1+incompatible
-	github.com/cloudquery/cq-provider-sdk v0.8.3
+	github.com/cloudquery/cq-provider-sdk v0.8.4
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -318,10 +318,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.8.2 h1:qvDmEyFpy8KeJgK0IMfP/yxu83wpN0e4eFsYXjlH0Pg=
-github.com/cloudquery/cq-provider-sdk v0.8.2/go.mod h1:IHxqY7TOttWhNQhMRqYl1vBo2JS2szLAf5Mhg78MwTQ=
-github.com/cloudquery/cq-provider-sdk v0.8.3 h1:NdOS3PK6E+4SblT7yB6PTg/tx24G1A9oNrIr+SH5OQs=
-github.com/cloudquery/cq-provider-sdk v0.8.3/go.mod h1:IHxqY7TOttWhNQhMRqYl1vBo2JS2szLAf5Mhg78MwTQ=
+github.com/cloudquery/cq-provider-sdk v0.8.4 h1:rwVtBpk5Xe7/dBioGgeNbmAKwM3eoo+PPWV4HP/sG5s=
+github.com/cloudquery/cq-provider-sdk v0.8.4/go.mod h1:IHxqY7TOttWhNQhMRqYl1vBo2JS2szLAf5Mhg78MwTQ=
 github.com/cloudquery/faker/v3 v3.7.4/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=

--- a/resources/provider/migrations/postgres/20_v0.10.9.down.sql
+++ b/resources/provider/migrations/postgres/20_v0.10.9.down.sql
@@ -1,0 +1,7 @@
+-- Resource: directconnect.gateways
+ALTER TABLE IF EXISTS "aws_directconnect_gateways" ADD COLUMN IF NOT EXISTS "region" text;
+
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    DROP CONSTRAINT aws_directconnect_gateways_pk;
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    ADD CONSTRAINT aws_directconnect_gateways_pk PRIMARY KEY (account_id,region,id);

--- a/resources/provider/migrations/postgres/20_v0.10.9.up.sql
+++ b/resources/provider/migrations/postgres/20_v0.10.9.up.sql
@@ -1,0 +1,9 @@
+-- Resource: directconnect.gateways
+TRUNCATE aws_directconnect_gateways CASCADE;
+
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    DROP CONSTRAINT aws_directconnect_gateways_pk;
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    ADD CONSTRAINT aws_directconnect_gateways_pk PRIMARY KEY (account_id,id);
+
+ALTER TABLE IF EXISTS "aws_directconnect_gateways" DROP COLUMN IF EXISTS "region";

--- a/resources/provider/migrations/timescale/20_v0.10.9.down.sql
+++ b/resources/provider/migrations/timescale/20_v0.10.9.down.sql
@@ -1,0 +1,7 @@
+-- Resource: directconnect.gateways
+ALTER TABLE IF EXISTS "aws_directconnect_gateways" ADD COLUMN IF NOT EXISTS "region" text;
+
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+DROP CONSTRAINT aws_directconnect_gateways_pk;
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    ADD CONSTRAINT aws_directconnect_gateways_pk PRIMARY KEY (cq_fetch_date,account_id,region,id);

--- a/resources/provider/migrations/timescale/20_v0.10.9.up.sql
+++ b/resources/provider/migrations/timescale/20_v0.10.9.up.sql
@@ -1,0 +1,9 @@
+-- Resource: directconnect.gateways
+TRUNCATE aws_directconnect_gateways CASCADE;
+
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    DROP CONSTRAINT aws_directconnect_gateways_pk;
+ALTER TABLE IF EXISTS aws_directconnect_gateways
+    ADD CONSTRAINT aws_directconnect_gateways_pk PRIMARY KEY (cq_fetch_date,account_id,id);
+
+ALTER TABLE IF EXISTS "aws_directconnect_gateways" DROP COLUMN IF EXISTS "region";

--- a/resources/services/directconnect/gateways.go
+++ b/resources/services/directconnect/gateways.go
@@ -18,7 +18,7 @@ func DirectconnectGateways() *schema.Table {
 		Resolver:      fetchDirectconnectGateways,
 		Multiplex:     client.AccountMultiplex,
 		IgnoreError:   client.IgnoreAccessDeniedServiceDisabled,
-		DeleteFilter:  client.DeleteAccountRegionFilter,
+		DeleteFilter:  client.DeleteAccountFilter,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		IgnoreInTests: true,
 		Columns: []schema.Column{

--- a/resources/services/directconnect/gateways.go
+++ b/resources/services/directconnect/gateways.go
@@ -16,10 +16,10 @@ func DirectconnectGateways() *schema.Table {
 		Name:          "aws_directconnect_gateways",
 		Description:   "Information about a Direct Connect gateway, which enables you to connect virtual interfaces and virtual private gateway or transit gateways.",
 		Resolver:      fetchDirectconnectGateways,
-		Multiplex:     client.ServiceAccountRegionMultiplexer("directconnect"),
+		Multiplex:     client.AccountMultiplex,
 		IgnoreError:   client.IgnoreAccessDeniedServiceDisabled,
 		DeleteFilter:  client.DeleteAccountRegionFilter,
-		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
+		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		IgnoreInTests: true,
 		Columns: []schema.Column{
 			{
@@ -27,12 +27,6 @@ func DirectconnectGateways() *schema.Table {
 				Description: "The AWS Account ID of the resource.",
 				Type:        schema.TypeString,
 				Resolver:    client.ResolveAWSAccount,
-			},
-			{
-				Name:        "region",
-				Description: "The AWS Region of the resource.",
-				Type:        schema.TypeString,
-				Resolver:    client.ResolveAWSRegion,
 			},
 			{
 				Name:        "arn",
@@ -226,9 +220,7 @@ func fetchDirectconnectGateways(ctx context.Context, meta schema.ClientMeta, par
 	c := meta.(*client.Client)
 	svc := c.Services().Directconnect
 	for {
-		output, err := svc.DescribeDirectConnectGateways(ctx, &config, func(options *directconnect.Options) {
-			options.Region = c.Region
-		})
+		output, err := svc.DescribeDirectConnectGateways(ctx, &config)
 		if err != nil {
 			return err
 		}
@@ -247,9 +239,7 @@ func fetchDirectconnectGatewayAssociations(ctx context.Context, meta schema.Clie
 	svc := c.Services().Directconnect
 	config := directconnect.DescribeDirectConnectGatewayAssociationsInput{DirectConnectGatewayId: gateway.DirectConnectGatewayId}
 	for {
-		output, err := svc.DescribeDirectConnectGatewayAssociations(ctx, &config, func(options *directconnect.Options) {
-			options.Region = c.Region
-		})
+		output, err := svc.DescribeDirectConnectGatewayAssociations(ctx, &config)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A Direct Connect gateway is a globally available resource. You can create the Direct Connect gateway in any Region and access it from all other Regions. The following describe scenarios where you can use a Direct Connect gateway.[[^]](https://docs.aws.amazon.com/directconnect/latest/UserGuide/direct-connect-gateways-intro.html)
