### PR TITLE
fix: Drift: aws_cloudfront_distribution_origins should only include rows with origin_access_identity set

### DIFF
--- a/resources/provider/moduledata/drift/1/drift.hcl
+++ b/resources/provider/moduledata/drift/1/drift.hcl
@@ -320,6 +320,9 @@ provider "aws" {
 
   resource "aws_cloudfront_distribution_origins" {
     identifiers = [ sql("SPLIT_PART(c.s3_origin_config_origin_access_identity,'/', 3)") ]
+    filters = [
+      "c.s3_origin_config_origin_access_identity IS NOT NULL AND c.s3_origin_config_origin_access_identity!=''"
+    ]
 
     iac {
       terraform {


### PR DESCRIPTION
We match `aws_cloudfront_distribution_origins` to `aws_cloudfront_origin_access_identity` in terraform, so distribution origins without an origin_access_identity seem to be giving confusing results.