### PR TITLE
fix: Drift: Match ec2.images with id/region

### DIFF
--- a/resources/provider/moduledata/drift/1/drift.hcl
+++ b/resources/provider/moduledata/drift/1/drift.hcl
@@ -648,10 +648,14 @@ provider "aws" {
   }
 
   resource "ec2.images" {
-    identifiers = [ sql("tags->>'Ec2ImageBuilderArn'") ]
+    identifiers = [ "id", "region" ]
     iac {
       terraform {
         type = "aws_imagebuilder_image"
+        identifiers = [
+          "output_resources.#.amis.#.image|@flatten|0",
+          "output_resources.#.amis.#.region|@flatten|0",
+        ]
       }
     }
   }


### PR DESCRIPTION
This is the smarter approach, as confirmed by a user in Discord.

Ref: https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/imagebuilder/image.go#L103