### PR TITLE
refactor: Remove type assertion

### DIFF
--- a/resources/services/apigateway/domain_names.go
+++ b/resources/services/apigateway/domain_names.go
@@ -2,7 +2,6 @@ package apigateway
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
@@ -218,10 +217,7 @@ func fetchApigatewayDomainNames(ctx context.Context, meta schema.ClientMeta, par
 	return nil
 }
 func fetchApigatewayDomainNameBasePathMappings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.DomainName)
-	if !ok {
-		return fmt.Errorf("expected DomainName but got %T", r)
-	}
+	r := parent.Item.(types.DomainName)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetBasePathMappingsInput{DomainName: r.DomainName}

--- a/resources/services/apigateway/rest_apis.go
+++ b/resources/services/apigateway/rest_apis.go
@@ -2,7 +2,6 @@ package apigateway
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
@@ -768,10 +767,7 @@ func fetchApigatewayRestApis(ctx context.Context, meta schema.ClientMeta, parent
 	return nil
 }
 func fetchApigatewayRestApiAuthorizers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetAuthorizersInput{RestApiId: r.Id}
@@ -791,10 +787,7 @@ func fetchApigatewayRestApiAuthorizers(ctx context.Context, meta schema.ClientMe
 	return nil
 }
 func fetchApigatewayRestApiDeployments(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetDeploymentsInput{RestApiId: r.Id}
@@ -814,10 +807,7 @@ func fetchApigatewayRestApiDeployments(ctx context.Context, meta schema.ClientMe
 	return nil
 }
 func fetchApigatewayRestApiDocumentationParts(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetDocumentationPartsInput{RestApiId: r.Id}
@@ -837,10 +827,7 @@ func fetchApigatewayRestApiDocumentationParts(ctx context.Context, meta schema.C
 	return nil
 }
 func fetchApigatewayRestApiDocumentationVersions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetDocumentationVersionsInput{RestApiId: r.Id}
@@ -860,10 +847,7 @@ func fetchApigatewayRestApiDocumentationVersions(ctx context.Context, meta schem
 	return nil
 }
 func fetchApigatewayRestApiGatewayResponses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetGatewayResponsesInput{RestApiId: r.Id}
@@ -883,10 +867,7 @@ func fetchApigatewayRestApiGatewayResponses(ctx context.Context, meta schema.Cli
 	return nil
 }
 func fetchApigatewayRestApiModels(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetModelsInput{RestApiId: r.Id}
@@ -906,14 +887,8 @@ func fetchApigatewayRestApiModels(ctx context.Context, meta schema.ClientMeta, p
 	return nil
 }
 func resolveApigatewayRestAPIModelModelTemplate(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.Model)
-	if !ok {
-		return fmt.Errorf("expected Model but got %T", r)
-	}
-	api, ok := resource.Parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := resource.Item.(types.Model)
+	api := resource.Parent.Item.(types.RestApi)
 	cl := meta.(*client.Client)
 	svc := cl.Services().Apigateway
 
@@ -942,10 +917,7 @@ func resolveApigatewayRestAPIModelModelTemplate(ctx context.Context, meta schema
 	return resource.Set(c.Name, response.Value)
 }
 func fetchApigatewayRestApiRequestValidators(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetRequestValidatorsInput{RestApiId: r.Id}
@@ -965,10 +937,7 @@ func fetchApigatewayRestApiRequestValidators(ctx context.Context, meta schema.Cl
 	return nil
 }
 func fetchApigatewayRestApiResources(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetResourcesInput{RestApiId: r.Id}
@@ -988,10 +957,7 @@ func fetchApigatewayRestApiResources(ctx context.Context, meta schema.ClientMeta
 	return nil
 }
 func fetchApigatewayRestApiStages(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.RestApi)
-	if !ok {
-		return fmt.Errorf("expected RestApi but got %T", r)
-	}
+	r := parent.Item.(types.RestApi)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetStagesInput{RestApiId: r.Id}

--- a/resources/services/apigateway/usage_plans.go
+++ b/resources/services/apigateway/usage_plans.go
@@ -2,7 +2,6 @@ package apigateway
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
@@ -219,18 +218,12 @@ func fetchApigatewayUsagePlans(ctx context.Context, meta schema.ClientMeta, pare
 	return nil
 }
 func fetchApigatewayUsagePlanApiStages(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.UsagePlan)
-	if !ok {
-		return fmt.Errorf("expected UsagePlan but got %T", r)
-	}
+	r := parent.Item.(types.UsagePlan)
 	res <- r.ApiStages
 	return nil
 }
 func fetchApigatewayUsagePlanKeys(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.UsagePlan)
-	if !ok {
-		return fmt.Errorf("expected UsagePlan but got %T", r)
-	}
+	r := parent.Item.(types.UsagePlan)
 	c := meta.(*client.Client)
 	svc := c.Services().Apigateway
 	config := apigateway.GetUsagePlanKeysInput{UsagePlanId: r.Id}

--- a/resources/services/apigatewayv2/apis.go
+++ b/resources/services/apigatewayv2/apis.go
@@ -2,7 +2,6 @@ package apigatewayv2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
@@ -917,10 +916,7 @@ func fetchApigatewayv2Apis(ctx context.Context, meta schema.ClientMeta, parent *
 	return nil
 }
 func fetchApigatewayv2ApiAuthorizers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Api)
 	config := apigatewayv2.GetAuthorizersInput{
 		ApiId: r.ApiId,
 	}
@@ -943,10 +939,7 @@ func fetchApigatewayv2ApiAuthorizers(ctx context.Context, meta schema.ClientMeta
 	return nil
 }
 func fetchApigatewayv2ApiDeployments(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Api)
 	config := apigatewayv2.GetDeploymentsInput{
 		ApiId: r.ApiId,
 	}
@@ -969,10 +962,7 @@ func fetchApigatewayv2ApiDeployments(ctx context.Context, meta schema.ClientMeta
 	return nil
 }
 func fetchApigatewayv2ApiIntegrations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Api)
 	config := apigatewayv2.GetIntegrationsInput{
 		ApiId: r.ApiId,
 	}
@@ -995,14 +985,8 @@ func fetchApigatewayv2ApiIntegrations(ctx context.Context, meta schema.ClientMet
 	return nil
 }
 func fetchApigatewayv2ApiIntegrationResponses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Integration)
-	if !ok {
-		return fmt.Errorf("expected Integration but got %T", r)
-	}
-	p, ok := parent.Parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Integration)
+	p := parent.Parent.Item.(types.Api)
 	config := apigatewayv2.GetIntegrationResponsesInput{
 		ApiId:         p.ApiId,
 		IntegrationId: r.IntegrationId,
@@ -1026,10 +1010,7 @@ func fetchApigatewayv2ApiIntegrationResponses(ctx context.Context, meta schema.C
 	return nil
 }
 func fetchApigatewayv2ApiModels(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Api)
 	config := apigatewayv2.GetModelsInput{
 		ApiId: r.ApiId,
 	}
@@ -1052,14 +1033,8 @@ func fetchApigatewayv2ApiModels(ctx context.Context, meta schema.ClientMeta, par
 	return nil
 }
 func resolveApigatewayv2apiModelModelTemplate(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.Model)
-	if !ok {
-		return fmt.Errorf("expected Model but got %T", r)
-	}
-	p, ok := resource.Parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := resource.Item.(types.Model)
+	p := resource.Parent.Item.(types.Api)
 	config := apigatewayv2.GetModelTemplateInput{
 		ApiId:   p.ApiId,
 		ModelId: r.ModelId,
@@ -1076,10 +1051,7 @@ func resolveApigatewayv2apiModelModelTemplate(ctx context.Context, meta schema.C
 	return resource.Set(c.Name, response.Value)
 }
 func fetchApigatewayv2ApiRoutes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected api but got %T", r)
-	}
+	r := parent.Item.(types.Api)
 	config := apigatewayv2.GetRoutesInput{
 		ApiId: r.ApiId,
 	}
@@ -1102,14 +1074,8 @@ func fetchApigatewayv2ApiRoutes(ctx context.Context, meta schema.ClientMeta, par
 	return nil
 }
 func fetchApigatewayv2ApiRouteResponses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Route)
-	if !ok {
-		return fmt.Errorf("expected Route but got %T", r)
-	}
-	p, ok := parent.Parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Route)
+	p := parent.Parent.Item.(types.Api)
 	config := apigatewayv2.GetRouteResponsesInput{
 		ApiId:   p.ApiId,
 		RouteId: r.RouteId,
@@ -1133,10 +1099,7 @@ func fetchApigatewayv2ApiRouteResponses(ctx context.Context, meta schema.ClientM
 	return nil
 }
 func fetchApigatewayv2ApiStages(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Api)
-	if !ok {
-		return fmt.Errorf("expected Api but got %T", r)
-	}
+	r := parent.Item.(types.Api)
 	config := apigatewayv2.GetStagesInput{
 		ApiId: r.ApiId,
 	}

--- a/resources/services/apigatewayv2/domain_names.go
+++ b/resources/services/apigatewayv2/domain_names.go
@@ -2,7 +2,6 @@ package apigatewayv2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
@@ -216,19 +215,13 @@ func fetchApigatewayv2DomainNames(ctx context.Context, meta schema.ClientMeta, _
 }
 
 func fetchApigatewayv2DomainNameConfigurations(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.DomainName)
-	if !ok {
-		return fmt.Errorf("expected DomainName but got %T", r)
-	}
+	r := parent.Item.(types.DomainName)
 	res <- r.DomainNameConfigurations
 	return nil
 }
 
 func fetchApigatewayv2DomainNameRestApiMappings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.DomainName)
-	if !ok {
-		return fmt.Errorf("expected DomainName but got %T", r)
-	}
+	r := parent.Item.(types.DomainName)
 	config := apigatewayv2.GetApiMappingsInput{
 		DomainName: r.DomainName,
 	}

--- a/resources/services/autoscaling/groups.go
+++ b/resources/services/autoscaling/groups.go
@@ -3,7 +3,6 @@ package autoscaling
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
@@ -599,10 +598,7 @@ func fetchAutoscalingGroups(ctx context.Context, meta schema.ClientMeta, parent 
 	// return nil
 }
 func resolveAutoscalingGroupLoadBalancers(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", resource.Item)
-	}
+	p := resource.Item.(autoscalingGroupWrapper)
 	client := meta.(*client.Client)
 	svc := client.Services().Autoscaling
 	config := autoscaling.DescribeLoadBalancersInput{AutoScalingGroupName: p.AutoScalingGroupName}
@@ -626,10 +622,7 @@ func resolveAutoscalingGroupLoadBalancers(ctx context.Context, meta schema.Clien
 	return resource.Set(c.Name, j)
 }
 func resolveAutoscalingGroupLoadBalancerTargetGroups(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", resource.Item)
-	}
+	p := resource.Item.(autoscalingGroupWrapper)
 	client := meta.(*client.Client)
 	svc := client.Services().Autoscaling
 	config := autoscaling.DescribeLoadBalancerTargetGroupsInput{AutoScalingGroupName: p.AutoScalingGroupName}
@@ -653,10 +646,7 @@ func resolveAutoscalingGroupLoadBalancerTargetGroups(ctx context.Context, meta s
 	return resource.Set(c.Name, j)
 }
 func resolveAutoscalingGroupNotificationsConfigurations(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", resource.Item)
-	}
+	p := resource.Item.(autoscalingGroupWrapper)
 	j := map[string]interface{}{}
 	for _, n := range p.NotificationConfigurations {
 		j[*n.NotificationType] = *n.TopicARN
@@ -664,10 +654,7 @@ func resolveAutoscalingGroupNotificationsConfigurations(ctx context.Context, met
 	return resource.Set(c.Name, j)
 }
 func resolveAutoscalingGroupsEnabledMetrics(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", resource.Item)
-	}
+	p := resource.Item.(autoscalingGroupWrapper)
 	j := map[string]interface{}{}
 	for _, em := range p.EnabledMetrics {
 		j[*em.Metric] = *em.Granularity
@@ -676,10 +663,7 @@ func resolveAutoscalingGroupsEnabledMetrics(ctx context.Context, meta schema.Cli
 	return resource.Set(c.Name, j)
 }
 func resolveAutoscalingGroupsSuspendedProcesses(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", resource.Item)
-	}
+	p := resource.Item.(autoscalingGroupWrapper)
 	j := map[string]interface{}{}
 	for _, sp := range p.SuspendedProcesses {
 		j[*sp.ProcessName] = *sp.SuspensionReason
@@ -688,26 +672,17 @@ func resolveAutoscalingGroupsSuspendedProcesses(ctx context.Context, meta schema
 	return resource.Set(c.Name, j)
 }
 func fetchAutoscalingGroupInstances(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", parent.Item)
-	}
+	p := parent.Item.(autoscalingGroupWrapper)
 	res <- p.Instances
 	return nil
 }
 func fetchAutoscalingGroupTags(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", parent.Item)
-	}
+	p := parent.Item.(autoscalingGroupWrapper)
 	res <- p.Tags
 	return nil
 }
 func fetchAutoscalingGroupScalingPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", parent.Item)
-	}
+	p := parent.Item.(autoscalingGroupWrapper)
 	client := meta.(*client.Client)
 	svc := client.Services().Autoscaling
 	config := autoscaling.DescribePoliciesInput{AutoScalingGroupName: p.AutoScalingGroupName}
@@ -729,10 +704,7 @@ func fetchAutoscalingGroupScalingPolicies(ctx context.Context, meta schema.Clien
 	return nil
 }
 func resolveAutoscalingGroupScalingPoliciesAlarms(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.ScalingPolicy)
-	if !ok {
-		return fmt.Errorf("expected to have types.ScalingPolicy but got %T", resource.Item)
-	}
+	p := resource.Item.(types.ScalingPolicy)
 	j := map[string]interface{}{}
 	for _, a := range p.Alarms {
 		j[*a.AlarmName] = *a.AlarmARN
@@ -740,10 +712,7 @@ func resolveAutoscalingGroupScalingPoliciesAlarms(ctx context.Context, meta sche
 	return resource.Set(c.Name, j)
 }
 func resolveAutoscalingGroupScalingPoliciesStepAdjustments(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.ScalingPolicy)
-	if !ok {
-		return fmt.Errorf("expected to have types.ScalingPolicy but got %T", resource.Item)
-	}
+	p := resource.Item.(types.ScalingPolicy)
 	data, err := json.Marshal(p.StepAdjustments)
 	if err != nil {
 		return diag.WrapError(err)
@@ -751,10 +720,7 @@ func resolveAutoscalingGroupScalingPoliciesStepAdjustments(ctx context.Context, 
 	return resource.Set(c.Name, data)
 }
 func resolveAutoscalingGroupScalingPoliciesTargetTrackingConfigurationCustomizedMetricDimensions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.ScalingPolicy)
-	if !ok {
-		return fmt.Errorf("expected to have types.ScalingPolicy but got %T", resource.Item)
-	}
+	p := resource.Item.(types.ScalingPolicy)
 	if p.TargetTrackingConfiguration == nil || p.TargetTrackingConfiguration.CustomizedMetricSpecification == nil {
 		return nil
 	}
@@ -765,10 +731,7 @@ func resolveAutoscalingGroupScalingPoliciesTargetTrackingConfigurationCustomized
 	return resource.Set(c.Name, j)
 }
 func fetchAutoscalingGroupLifecycleHooks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(autoscalingGroupWrapper)
-	if !ok {
-		return fmt.Errorf("expected to have autoscalingGroupWrapper but got %T", parent.Item)
-	}
+	p := parent.Item.(autoscalingGroupWrapper)
 	client := meta.(*client.Client)
 	svc := client.Services().Autoscaling
 	config := autoscaling.DescribeLifecycleHooksInput{AutoScalingGroupName: p.AutoScalingGroupName}

--- a/resources/services/cloudfront/distributions.go
+++ b/resources/services/cloudfront/distributions.go
@@ -2,7 +2,6 @@ package cloudfront
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
@@ -792,10 +791,7 @@ func fetchCloudfrontDistributions(ctx context.Context, meta schema.ClientMeta, p
 	return nil
 }
 func resolveCloudfrontDistributionTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	distribution, ok := resource.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("expected types.Distribution but got %T", resource.Item)
-	}
+	distribution := resource.Item.(types.Distribution)
 
 	client := meta.(*client.Client)
 	svc := client.Services().Cloudfront
@@ -815,10 +811,7 @@ func resolveCloudfrontDistributionTags(ctx context.Context, meta schema.ClientMe
 	return resource.Set(c.Name, tags)
 }
 func resolveCloudfrontDistributionsActiveTrustedKeyGroups(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	distribution, ok := resource.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := resource.Item.(types.Distribution)
 	if distribution.ActiveTrustedKeyGroups == nil {
 		return nil
 	}
@@ -829,10 +822,7 @@ func resolveCloudfrontDistributionsActiveTrustedKeyGroups(ctx context.Context, m
 	return resource.Set(c.Name, j)
 }
 func resolveCloudfrontDistributionsActiveTrustedSigners(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	distribution, ok := resource.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := resource.Item.(types.Distribution)
 	if distribution.ActiveTrustedSigners == nil {
 		return nil
 	}
@@ -843,10 +833,7 @@ func resolveCloudfrontDistributionsActiveTrustedSigners(ctx context.Context, met
 	return resource.Set(c.Name, j)
 }
 func resolveCloudfrontDistributionsAliasIcpRecordals(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	distribution, ok := resource.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := resource.Item.(types.Distribution)
 	j := map[string]interface{}{}
 	for _, a := range distribution.AliasICPRecordals {
 		j[*a.CNAME] = a.ICPRecordalStatus
@@ -854,18 +841,12 @@ func resolveCloudfrontDistributionsAliasIcpRecordals(ctx context.Context, meta s
 	return resource.Set(c.Name, j)
 }
 func fetchCloudfrontDistributionDefaultCacheBehaviorLambdaFunctions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("types.Distribution")
-	}
+	r := parent.Item.(types.Distribution)
 	res <- r.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations.Items
 	return nil
 }
 func fetchCloudfrontDistributionOrigins(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	distribution, ok := parent.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := parent.Item.(types.Distribution)
 	if distribution.DistributionConfig.Origins == nil {
 		return nil
 	}
@@ -884,20 +865,14 @@ func resolveCloudfrontDistributionOriginsCustomHeaders(ctx context.Context, meta
 	return resource.Set(c.Name, tags)
 }
 func fetchCloudfrontDistributionCacheBehaviors(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	distribution, ok := parent.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := parent.Item.(types.Distribution)
 	if distribution.DistributionConfig.CacheBehaviors != nil {
 		res <- distribution.DistributionConfig.CacheBehaviors.Items
 	}
 	return nil
 }
 func fetchCloudfrontDistributionCacheBehaviorLambdaFunctions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cacheBehavior, ok := parent.Item.(types.CacheBehavior)
-	if !ok {
-		return fmt.Errorf("not types.CacheBehavior")
-	}
+	cacheBehavior := parent.Item.(types.CacheBehavior)
 	if cacheBehavior.LambdaFunctionAssociations == nil {
 		return nil
 	}
@@ -905,30 +880,21 @@ func fetchCloudfrontDistributionCacheBehaviorLambdaFunctions(ctx context.Context
 	return nil
 }
 func fetchCloudfrontDistributionCustomErrorResponses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	distribution, ok := parent.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := parent.Item.(types.Distribution)
 	if distribution.DistributionConfig.CustomErrorResponses != nil {
 		res <- distribution.DistributionConfig.CustomErrorResponses.Items
 	}
 	return nil
 }
 func fetchCloudfrontDistributionOriginGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	distribution, ok := parent.Item.(types.Distribution)
-	if !ok {
-		return fmt.Errorf("not types.Distribution")
-	}
+	distribution := parent.Item.(types.Distribution)
 	if distribution.DistributionConfig.OriginGroups != nil {
 		res <- distribution.DistributionConfig.OriginGroups.Items
 	}
 	return nil
 }
 func resolveCloudfrontDistributionOriginGroupsFailoverCriteriaStatusCodes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	origin, ok := resource.Item.(types.OriginGroup)
-	if !ok {
-		return fmt.Errorf("not types.OriginGroup")
-	}
+	origin := resource.Item.(types.OriginGroup)
 	if origin.FailoverCriteria == nil || origin.FailoverCriteria.StatusCodes == nil {
 		return nil
 	}

--- a/resources/services/cloudtrail/trails.go
+++ b/resources/services/cloudtrail/trails.go
@@ -317,10 +317,7 @@ func fetchCloudtrailTrails(ctx context.Context, meta schema.ClientMeta, parent *
 func postCloudtrailTrailResolver(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
 	c := meta.(*client.Client)
 	svc := c.Services().Cloudtrail
-	r, ok := resource.Item.(CloudTrailWrapper)
-	if !ok {
-		return fmt.Errorf("expected CloudTrailWrapper but got %T", resource.Item)
-	}
+	r := resource.Item.(CloudTrailWrapper)
 	response, err := svc.GetTrailStatus(ctx,
 		&cloudtrail.GetTrailStatusInput{Name: r.TrailARN}, func(o *cloudtrail.Options) {
 			o.Region = *r.HomeRegion
@@ -367,10 +364,7 @@ func postCloudtrailTrailResolver(ctx context.Context, meta schema.ClientMeta, re
 func resolveCloudtrailTrailCloudwatchLogsLogGroupName(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	groupName := ""
 	log := meta.(*client.Client).Logger()
-	r, ok := resource.Item.(CloudTrailWrapper)
-	if !ok {
-		return fmt.Errorf("expected CloudTrailWrapper but got %T", resource.Item)
-	}
+	r := resource.Item.(CloudTrailWrapper)
 	if r.CloudWatchLogsLogGroupArn != nil {
 		matches := client.GroupNameRegex.FindStringSubmatch(*r.CloudWatchLogsLogGroupArn)
 		if len(matches) < 2 {
@@ -386,10 +380,7 @@ func resolveCloudtrailTrailCloudwatchLogsLogGroupName(ctx context.Context, meta 
 }
 
 func fetchCloudtrailTrailEventSelectors(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(CloudTrailWrapper)
-	if !ok {
-		return fmt.Errorf("expected CloudTrailWrapper but got %T", parent.Item)
-	}
+	r := parent.Item.(CloudTrailWrapper)
 	c := meta.(*client.Client)
 	svc := c.Services().Cloudtrail
 	response, err := svc.GetEventSelectors(ctx, &cloudtrail.GetEventSelectorsInput{TrailName: r.TrailARN}, func(options *cloudtrail.Options) {

--- a/resources/services/codebuild/projects.go
+++ b/resources/services/codebuild/projects.go
@@ -3,7 +3,6 @@ package codebuild
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
@@ -718,10 +717,7 @@ func fetchCodebuildProjects(ctx context.Context, meta schema.ClientMeta, parent 
 	return nil
 }
 func resolveCodebuildProjectsSecondarySourceVersions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", resource.Item)
-	}
+	p := resource.Item.(types.Project)
 	j := map[string]interface{}{}
 	for _, v := range p.SecondarySourceVersions {
 		j[*v.SourceIdentifier] = *v.SourceVersion
@@ -729,10 +725,7 @@ func resolveCodebuildProjectsSecondarySourceVersions(ctx context.Context, meta s
 	return resource.Set(c.Name, j)
 }
 func resolveCodebuildProjectsTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", resource.Item)
-	}
+	p := resource.Item.(types.Project)
 	j := map[string]interface{}{}
 	for _, v := range p.Tags {
 		j[*v.Key] = *v.Value
@@ -740,10 +733,7 @@ func resolveCodebuildProjectsTags(ctx context.Context, meta schema.ClientMeta, r
 	return resource.Set(c.Name, j)
 }
 func resolveCodebuildProjectsWebhookFilterGroups(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", resource.Item)
-	}
+	p := resource.Item.(types.Project)
 	if p.Webhook == nil {
 		return nil
 	}
@@ -754,10 +744,7 @@ func resolveCodebuildProjectsWebhookFilterGroups(ctx context.Context, meta schem
 	return resource.Set(c.Name, data)
 }
 func fetchCodebuildProjectEnvironmentVariables(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", parent.Item)
-	}
+	p := parent.Item.(types.Project)
 	if p.Environment == nil {
 		return nil
 	}
@@ -765,26 +752,17 @@ func fetchCodebuildProjectEnvironmentVariables(ctx context.Context, meta schema.
 	return nil
 }
 func fetchCodebuildProjectFileSystemLocations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", parent.Item)
-	}
+	p := parent.Item.(types.Project)
 	res <- p.FileSystemLocations
 	return nil
 }
 func fetchCodebuildProjectSecondaryArtifacts(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", parent.Item)
-	}
+	p := parent.Item.(types.Project)
 	res <- p.SecondaryArtifacts
 	return nil
 }
 func fetchCodebuildProjectSecondarySources(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.Project)
-	if !ok {
-		return fmt.Errorf("not a types.Project instance: %T", parent.Item)
-	}
+	p := parent.Item.(types.Project)
 	res <- p.SecondarySources
 	return nil
 }

--- a/resources/services/cognito/identity_pools.go
+++ b/resources/services/cognito/identity_pools.go
@@ -2,7 +2,6 @@ package cognito
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
@@ -166,10 +165,7 @@ func fetchCognitoIdentityPools(ctx context.Context, meta schema.ClientMeta, pare
 }
 
 func fetchCognitoIdentityPoolCognitoIdentityProviders(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	pool, ok := parent.Item.(*cognitoidentity.DescribeIdentityPoolOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeIdentityPoolOutput instance: %#v", parent.Item)
-	}
+	pool := parent.Item.(*cognitoidentity.DescribeIdentityPoolOutput)
 	res <- pool.CognitoIdentityProviders
 	return nil
 }

--- a/resources/services/cognito/user_pools.go
+++ b/resources/services/cognito/user_pools.go
@@ -3,7 +3,6 @@ package cognito
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
@@ -619,10 +618,7 @@ func fetchCognitoUserPools(ctx context.Context, meta schema.ClientMeta, parent *
 }
 
 func resolveCognitoUserPoolAccountRecoverySetting(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	pool, ok := resource.Item.(*types.UserPoolType)
-	if !ok {
-		return fmt.Errorf("not a UserPoolType instance: %#v", resource.Item)
-	}
+	pool := resource.Item.(*types.UserPoolType)
 	data, err := json.Marshal(pool.AccountRecoverySetting)
 	if err != nil {
 		return diag.WrapError(err)
@@ -631,19 +627,13 @@ func resolveCognitoUserPoolAccountRecoverySetting(ctx context.Context, meta sche
 }
 
 func fetchCognitoUserPoolSchemaAttributes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	pool, ok := parent.Item.(*types.UserPoolType)
-	if !ok {
-		return fmt.Errorf("not a UserPoolType instance: %#v", parent.Item)
-	}
+	pool := parent.Item.(*types.UserPoolType)
 	res <- pool.SchemaAttributes
 	return nil
 }
 
 func fetchCognitoUserPoolIdentityProviders(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	pool, ok := parent.Item.(*types.UserPoolType)
-	if !ok {
-		return fmt.Errorf("not a UserPoolType instance: %#v", parent.Item)
-	}
+	pool := parent.Item.(*types.UserPoolType)
 	c := meta.(*client.Client)
 	svc := c.Services().CognitoUserPools
 	optsFunc := func(options *cognitoidentityprovider.Options) { options.Region = c.Region }

--- a/resources/services/config/configuration_recorders.go
+++ b/resources/services/config/configuration_recorders.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
@@ -168,10 +167,7 @@ func fetchConfigConfigurationRecorders(ctx context.Context, meta schema.ClientMe
 
 func generateConfigRecorderArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	cl := meta.(*client.Client)
-	cfg, ok := resource.Item.(configurationRecorderWrapper)
-	if !ok {
-		return fmt.Errorf("not config config recorder")
-	}
+	cfg := resource.Item.(configurationRecorderWrapper)
 	return resource.Set(c.Name, client.GenerateResourceARN("config", "config-recorder", *cfg.Name, cl.Region, cl.AccountID))
 }
 

--- a/resources/services/dax/clusters.go
+++ b/resources/services/dax/clusters.go
@@ -2,7 +2,6 @@ package dax
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dax"
@@ -251,10 +250,7 @@ func fetchDaxClusters(ctx context.Context, meta schema.ClientMeta, parent *schem
 	return nil
 }
 func resolveDaxClusterTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	cluster, ok := resource.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("expected types.Cluster but got %T", resource.Item)
-	}
+	cluster := resource.Item.(types.Cluster)
 
 	cl := meta.(*client.Client)
 	svc := cl.Services().DAX

--- a/resources/services/directconnect/connections.go
+++ b/resources/services/directconnect/connections.go
@@ -2,7 +2,6 @@ package directconnect
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/directconnect"
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
@@ -210,10 +209,7 @@ func resolveDirectconnectConnectionTags(ctx context.Context, meta schema.ClientM
 	return resource.Set("tags", tags)
 }
 func fetchDirectconnectConnectionMacSecKeys(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	connection, ok := parent.Item.(types.Connection)
-	if !ok {
-		return fmt.Errorf("not a direct connect connection")
-	}
+	connection := parent.Item.(types.Connection)
 	res <- connection.MacSecKeys
 	return nil
 }

--- a/resources/services/directconnect/virtual_interfaces.go
+++ b/resources/services/directconnect/virtual_interfaces.go
@@ -2,7 +2,6 @@ package directconnect
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/directconnect"
 	"github.com/aws/aws-sdk-go-v2/service/directconnect/types"
@@ -260,10 +259,7 @@ func resolveDirectconnectVirtualInterfaceTags(ctx context.Context, meta schema.C
 	return resource.Set("tags", tags)
 }
 func fetchDirectconnectVirtualInterfaceBgpPeers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	virtualInterface, ok := parent.Item.(types.VirtualInterface)
-	if !ok {
-		return fmt.Errorf("not a direct connect virtual interface")
-	}
+	virtualInterface := parent.Item.(types.VirtualInterface)
 	res <- virtualInterface.BgpPeers
 	return nil
 }

--- a/resources/services/dms/replication_instances.go
+++ b/resources/services/dms/replication_instances.go
@@ -2,7 +2,6 @@ package dms
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
@@ -306,19 +305,13 @@ func fetchDmsReplicationInstances(ctx context.Context, meta schema.ClientMeta, _
 }
 
 func fetchDmsReplicationInstanceReplicationSubnetGroupSubnets(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	replicationInstance, ok := parent.Item.(DmsReplicationInstanceWrapper)
-	if !ok {
-		return fmt.Errorf("not dms replication instance")
-	}
+	replicationInstance := parent.Item.(DmsReplicationInstanceWrapper)
 	res <- replicationInstance.ReplicationSubnetGroup.Subnets
 	return nil
 }
 
 func fetchDmsReplicationInstanceVpcSecurityGroups(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	replicationInstance, ok := parent.Item.(DmsReplicationInstanceWrapper)
-	if !ok {
-		return fmt.Errorf("not dms replication instance")
-	}
+	replicationInstance := parent.Item.(DmsReplicationInstanceWrapper)
 	res <- replicationInstance.VpcSecurityGroups
 	return nil
 }

--- a/resources/services/dynamodb/tables.go
+++ b/resources/services/dynamodb/tables.go
@@ -3,7 +3,6 @@ package dynamodb
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -534,10 +533,7 @@ func fetchDynamodbTables(ctx context.Context, meta schema.ClientMeta, parent *sc
 	return nil
 }
 func resolveDynamodbTableTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	table, ok := resource.Item.(*types.TableDescription)
-	if !ok {
-		return fmt.Errorf("expected *types.TableDescription but got %T", resource.Item)
-	}
+	table := resource.Item.(*types.TableDescription)
 
 	cl := meta.(*client.Client)
 	svc := cl.Services().DynamoDB
@@ -662,10 +658,7 @@ func resolveDynamodbTableReplicaGlobalSecondaryIndexes(ctx context.Context, meta
 	return resource.Set(c.Name, val)
 }
 func fetchDynamodbTableReplicaAutoScalings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	par, ok := parent.Item.(*types.TableDescription)
-	if !ok {
-		return fmt.Errorf("expected *types.TableDescription but got %T", parent.Item)
-	}
+	par := parent.Item.(*types.TableDescription)
 
 	if aws.ToString(par.GlobalTableVersion) == "" {
 		// "This operation only applies to Version 2019.11.21 of global tables"
@@ -726,10 +719,7 @@ func resolveDynamodbTableReplicaAutoScalingWriteCapacity(ctx context.Context, me
 	return resource.Set(c.Name, marshalAutoScalingSettingsDescription(r.ReplicaProvisionedWriteCapacityAutoScalingSettings))
 }
 func fetchDynamodbTableContinuousBackups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	par, ok := parent.Item.(*types.TableDescription)
-	if !ok {
-		return fmt.Errorf("expected *types.TableDescription but got %T", parent.Item)
-	}
+	par := parent.Item.(*types.TableDescription)
 
 	c := meta.(*client.Client)
 	svc := c.Services().DynamoDB

--- a/resources/services/ec2/customer_gateways.go
+++ b/resources/services/ec2/customer_gateways.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -113,9 +112,6 @@ func resolveEc2customerGatewayTags(ctx context.Context, meta schema.ClientMeta, 
 
 func resolveCustomerGatewayArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	cl := meta.(*client.Client)
-	cg, ok := resource.Item.(types.CustomerGateway)
-	if !ok {
-		return fmt.Errorf("not ec2 customer-gateway")
-	}
+	cg := resource.Item.(types.CustomerGateway)
 	return resource.Set(c.Name, client.GenerateResourceARN("ec2", "customer-gateway", *cg.CustomerGatewayId, cl.Region, cl.AccountID))
 }

--- a/resources/services/ec2/ebs_volumes.go
+++ b/resources/services/ec2/ebs_volumes.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
@@ -178,19 +177,13 @@ func resolveEc2EbsVolumeTags(_ context.Context, _ schema.ClientMeta, resource *s
 	return resource.Set("tags", tags)
 }
 func fetchEc2EbsVolumeAttachments(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	volume, ok := parent.Item.(types.Volume)
-	if !ok {
-		return fmt.Errorf("not ec2 ebs volume")
-	}
+	volume := parent.Item.(types.Volume)
 	res <- volume.Attachments
 	return nil
 }
 
 func resolveEbsVolumeArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	cl := meta.(*client.Client)
-	ebs, ok := resource.Item.(types.Volume)
-	if !ok {
-		return fmt.Errorf("not ec2 ebs volume")
-	}
+	ebs := resource.Item.(types.Volume)
 	return resource.Set(c.Name, client.GenerateResourceARN("ec2", "volume", *ebs.VolumeId, cl.Region, cl.AccountID))
 }

--- a/resources/services/ec2/instance_statuses.go
+++ b/resources/services/ec2/instance_statuses.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -171,10 +170,7 @@ func fetchEc2InstanceStatuses(ctx context.Context, meta schema.ClientMeta, paren
 	return nil
 }
 func fetchEc2InstanceStatusEvents(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.InstanceStatus)
-	if !ok {
-		return fmt.Errorf("not ec2 instance status")
-	}
+	r := parent.Item.(types.InstanceStatus)
 	res <- r.Events
 	return nil
 }

--- a/resources/services/ec2/instances.go
+++ b/resources/services/ec2/instances.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"time"
 
@@ -852,10 +851,7 @@ func fetchEc2Instances(ctx context.Context, meta schema.ClientMeta, parent *sche
 	return nil
 }
 func resolveEc2InstanceStateTransitionReasonTime(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	instance, ok := resource.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := resource.Item.(types.Instance)
 	if instance.StateTransitionReason == nil {
 		return nil
 	}
@@ -874,10 +870,7 @@ func resolveEc2InstanceStateTransitionReasonTime(ctx context.Context, meta schem
 	return resource.Set(c.Name, tm)
 }
 func resolveEc2InstancesLicenses(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	instance, ok := resource.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := resource.Item.(types.Instance)
 	licenses := make([]string, len(instance.Licenses))
 	for i, l := range instance.Licenses {
 		licenses[i] = *l.LicenseConfigurationArn
@@ -893,42 +886,27 @@ func resolveEc2InstancesTags(ctx context.Context, meta schema.ClientMeta, resour
 	return resource.Set("tags", tags)
 }
 func fetchEc2InstanceBlockDeviceMappings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := parent.Item.(types.Instance)
 	res <- instance.BlockDeviceMappings
 	return nil
 }
 func fetchEc2InstanceElasticGpuAssociations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := parent.Item.(types.Instance)
 	res <- instance.ElasticGpuAssociations
 	return nil
 }
 func fetchEc2InstanceElasticInferenceAcceleratorAssociations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := parent.Item.(types.Instance)
 	res <- instance.ElasticInferenceAcceleratorAssociations
 	return nil
 }
 func fetchEc2InstanceNetworkInterfaces(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := parent.Item.(types.Instance)
 	res <- instance.NetworkInterfaces
 	return nil
 }
 func resolveEc2InstanceNetworkInterfacesIpv4Prefixes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	instanceNetworkInterface, ok := resource.Item.(types.InstanceNetworkInterface)
-	if !ok {
-		return fmt.Errorf("not ec2 instance network interface")
-	}
+	instanceNetworkInterface := resource.Item.(types.InstanceNetworkInterface)
 	ips := make([]string, 0, len(instanceNetworkInterface.Ipv4Prefixes))
 	for _, p := range instanceNetworkInterface.Ipv4Prefixes {
 		ips = append(ips, *p.Ipv4Prefix)
@@ -936,10 +914,7 @@ func resolveEc2InstanceNetworkInterfacesIpv4Prefixes(ctx context.Context, meta s
 	return resource.Set(c.Name, ips)
 }
 func resolveEc2InstanceNetworkInterfacesIpv6Prefixes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	instanceNetworkInterface, ok := resource.Item.(types.InstanceNetworkInterface)
-	if !ok {
-		return fmt.Errorf("not ec2 instance network interface")
-	}
+	instanceNetworkInterface := resource.Item.(types.InstanceNetworkInterface)
 	ips := make([]string, 0, len(instanceNetworkInterface.Ipv6Prefixes))
 	for _, p := range instanceNetworkInterface.Ipv6Prefixes {
 		ips = append(ips, *p.Ipv6Prefix)
@@ -947,42 +922,27 @@ func resolveEc2InstanceNetworkInterfacesIpv6Prefixes(ctx context.Context, meta s
 	return resource.Set(c.Name, ips)
 }
 func fetchEc2InstanceNetworkInterfaceGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instanceNetworkInterface, ok := parent.Item.(types.InstanceNetworkInterface)
-	if !ok {
-		return fmt.Errorf("not ec2 instance network interface")
-	}
+	instanceNetworkInterface := parent.Item.(types.InstanceNetworkInterface)
 	res <- instanceNetworkInterface.Groups
 	return nil
 }
 func fetchEc2InstanceNetworkInterfaceIpv6Addresses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instanceNetworkInterface, ok := parent.Item.(types.InstanceNetworkInterface)
-	if !ok {
-		return fmt.Errorf("not ec2 instance network interface")
-	}
+	instanceNetworkInterface := parent.Item.(types.InstanceNetworkInterface)
 	res <- instanceNetworkInterface.Ipv6Addresses
 	return nil
 }
 func fetchEc2InstanceNetworkInterfacePrivateIpAddresses(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instanceNetworkInterface, ok := parent.Item.(types.InstanceNetworkInterface)
-	if !ok {
-		return fmt.Errorf("not ec2 instance network interface")
-	}
+	instanceNetworkInterface := parent.Item.(types.InstanceNetworkInterface)
 	res <- instanceNetworkInterface.PrivateIpAddresses
 	return nil
 }
 func fetchEc2InstanceProductCodes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := parent.Item.(types.Instance)
 	res <- instance.ProductCodes
 	return nil
 }
 func fetchEc2InstanceSecurityGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.Instance)
-	if !ok {
-		return fmt.Errorf("not ec2 instance")
-	}
+	instance := parent.Item.(types.Instance)
 	res <- instance.SecurityGroups
 	return nil
 }

--- a/resources/services/ec2/regions.go
+++ b/resources/services/ec2/regions.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -70,10 +69,7 @@ func fetchRegions(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 }
 func resolveRegionEnabled(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 
-	region, ok := resource.Item.(types.Region)
-	if !ok {
-		return fmt.Errorf("expected types.Region got %T", resource.Item)
-	}
+	region := resource.Item.(types.Region)
 	switch *region.OptInStatus {
 	case "opt-in-not-required", "opted-in":
 		return resource.Set(c.Name, true)

--- a/resources/services/ec2/security_groups.go
+++ b/resources/services/ec2/security_groups.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -248,10 +247,7 @@ func resolveEc2securityGroupTags(ctx context.Context, meta schema.ClientMeta, re
 }
 func fetchEc2SecurityGroupIpPermissions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 
-	securityGroup, ok := parent.Item.(types.SecurityGroup)
-	if !ok {
-		return fmt.Errorf("not ec2 security group")
-	}
+	securityGroup := parent.Item.(types.SecurityGroup)
 
 	capacity := len(securityGroup.IpPermissionsEgress) + len(securityGroup.IpPermissions)
 
@@ -269,10 +265,7 @@ func fetchEc2SecurityGroupIpPermissions(ctx context.Context, meta schema.ClientM
 
 func fetchEc2SecurityGroupIpPermissionIpRanges(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 
-	securityGroupIpPermission, ok := parent.Item.(ipPermission)
-	if !ok {
-		return fmt.Errorf("not ec2 security group ip permission")
-	}
+	securityGroupIpPermission := parent.Item.(ipPermission)
 
 	type customIpRange struct {
 		Cidr        string
@@ -294,18 +287,12 @@ func fetchEc2SecurityGroupIpPermissionIpRanges(ctx context.Context, meta schema.
 	return nil
 }
 func fetchEc2SecurityGroupIpPermissionPrefixListIds(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	securityGroupIpPermission, ok := parent.Item.(ipPermission)
-	if !ok {
-		return fmt.Errorf("not ec2 security group ip permission in ip range")
-	}
+	securityGroupIpPermission := parent.Item.(ipPermission)
 	res <- securityGroupIpPermission.PrefixListIds
 	return nil
 }
 func fetchEc2SecurityGroupIpPermissionUserIdGroupPairs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	securityGroupIpPermission, ok := parent.Item.(ipPermission)
-	if !ok {
-		return fmt.Errorf("not ec2 security group ip permission in user id group pair")
-	}
+	securityGroupIpPermission := parent.Item.(ipPermission)
 	res <- securityGroupIpPermission.UserIdGroupPairs
 	return nil
 }

--- a/resources/services/ec2/transit_gateways.go
+++ b/resources/services/ec2/transit_gateways.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -411,10 +410,7 @@ func fetchEc2TransitGateways(ctx context.Context, meta schema.ClientMeta, parent
 }
 
 func fetchEc2TransitGatewayAttachments(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TransitGateway)
-	if !ok {
-		return fmt.Errorf("expected TransitGateway but got %T", r)
-	}
+	r := parent.Item.(types.TransitGateway)
 
 	config := ec2.DescribeTransitGatewayAttachmentsInput{
 		Filters: []types.Filter{
@@ -443,10 +439,7 @@ func fetchEc2TransitGatewayAttachments(ctx context.Context, meta schema.ClientMe
 }
 
 func fetchEc2TransitGatewayRouteTables(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TransitGateway)
-	if !ok {
-		return fmt.Errorf("expected TransitGateway but got %T", r)
-	}
+	r := parent.Item.(types.TransitGateway)
 
 	config := ec2.DescribeTransitGatewayRouteTablesInput{
 		Filters: []types.Filter{
@@ -476,10 +469,7 @@ func fetchEc2TransitGatewayRouteTables(ctx context.Context, meta schema.ClientMe
 
 func fetchEc2TransitGatewayVpcAttachments(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 
-	r, ok := parent.Item.(types.TransitGateway)
-	if !ok {
-		return fmt.Errorf("expected TransitGateway but got %T", r)
-	}
+	r := parent.Item.(types.TransitGateway)
 
 	config := ec2.DescribeTransitGatewayVpcAttachmentsInput{
 		Filters: []types.Filter{
@@ -508,10 +498,7 @@ func fetchEc2TransitGatewayVpcAttachments(ctx context.Context, meta schema.Clien
 }
 
 func fetchEc2TransitGatewayPeeringAttachments(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TransitGateway)
-	if !ok {
-		return fmt.Errorf("expected TransitGateway but got %T", r)
-	}
+	r := parent.Item.(types.TransitGateway)
 
 	config := ec2.DescribeTransitGatewayPeeringAttachmentsInput{
 		Filters: []types.Filter{
@@ -541,10 +528,7 @@ func fetchEc2TransitGatewayPeeringAttachments(ctx context.Context, meta schema.C
 }
 
 func fetchEc2TransitGatewayMulticastDomains(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TransitGateway)
-	if !ok {
-		return fmt.Errorf("expected TransitGateway but got %T", r)
-	}
+	r := parent.Item.(types.TransitGateway)
 
 	config := ec2.DescribeTransitGatewayMulticastDomainsInput{
 		Filters: []types.Filter{

--- a/resources/services/ec2/vpc_endpoints.go
+++ b/resources/services/ec2/vpc_endpoints.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -215,19 +214,13 @@ func resolveEc2vpcEndpointTags(ctx context.Context, meta schema.ClientMeta, reso
 	return resource.Set("tags", tags)
 }
 func fetchEc2VpcEndpointDnsEntries(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	endpoint, ok := parent.Item.(types.VpcEndpoint)
-	if !ok {
-		return fmt.Errorf("not vpc endpoint")
-	}
+	endpoint := parent.Item.(types.VpcEndpoint)
 	res <- endpoint.DnsEntries
 
 	return nil
 }
 func fetchEc2VpcEndpointGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	endpoint, ok := parent.Item.(types.VpcEndpoint)
-	if !ok {
-		return fmt.Errorf("not vpc endpoint")
-	}
+	endpoint := parent.Item.(types.VpcEndpoint)
 	res <- endpoint.Groups
 
 	return nil

--- a/resources/services/ecs/clusters.go
+++ b/resources/services/ecs/clusters.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -1104,10 +1103,7 @@ func resolveEcsClustersStatistics(ctx context.Context, meta schema.ClientMeta, r
 func resolveEcsClustersTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ECS
-	cluster, ok := resource.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("expected to have types.Cluster but got %T", resource.Item)
-	}
+	cluster := resource.Item.(types.Cluster)
 	listTagsForResourceOutput, err := svc.ListTagsForResource(ctx, &ecs.ListTagsForResourceInput{
 		ResourceArn: cluster.ClusterArn,
 	}, func(o *ecs.Options) {

--- a/resources/services/ecs/task_definitions.go
+++ b/resources/services/ecs/task_definitions.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -628,10 +627,7 @@ func fetchEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent
 	return nil
 }
 func resolveEcsTaskDefinitionsInferenceAccelerators(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.TaskDefinition)
 	j := map[string]interface{}{}
 	for _, a := range r.InferenceAccelerators {
 		j[*a.DeviceName] = *a.DeviceType
@@ -639,10 +635,7 @@ func resolveEcsTaskDefinitionsInferenceAccelerators(ctx context.Context, meta sc
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionsPlacementConstraints(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.TaskDefinition)
 	j := map[string]interface{}{}
 	for _, p := range r.PlacementConstraints {
 		j[*p.Expression] = p.Type
@@ -650,10 +643,7 @@ func resolveEcsTaskDefinitionsPlacementConstraints(ctx context.Context, meta sch
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionsProxyConfigurationProperties(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.TaskDefinition)
 	j := map[string]interface{}{}
 	if r.ProxyConfiguration == nil {
 		return nil
@@ -664,10 +654,7 @@ func resolveEcsTaskDefinitionsProxyConfigurationProperties(ctx context.Context, 
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionsRequiresAttributes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.TaskDefinition)
 	data, err := json.Marshal(r.RequiresAttributes)
 	if err != nil {
 		return diag.WrapError(err)
@@ -675,18 +662,12 @@ func resolveEcsTaskDefinitionsRequiresAttributes(ctx context.Context, meta schem
 	return resource.Set(c.Name, data)
 }
 func fetchEcsTaskDefinitionContainerDefinitions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", parent.Item)
-	}
+	r := parent.Item.(types.TaskDefinition)
 	res <- r.ContainerDefinitions
 	return nil
 }
 func resolveEcsTaskDefinitionContainerDefinitionsDependsOn(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	for _, p := range r.DependsOn {
 		j[*p.ContainerName] = p.Condition
@@ -694,10 +675,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsDependsOn(ctx context.Context, 
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsEnvironment(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	for _, p := range r.Environment {
 		j[*p.Name] = p.Value
@@ -705,10 +683,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsEnvironment(ctx context.Context
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsEnvironmentFiles(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	for _, p := range r.EnvironmentFiles {
 		j[string(p.Type)] = p.Value
@@ -716,10 +691,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsEnvironmentFiles(ctx context.Co
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsExtraHosts(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	for _, h := range r.ExtraHosts {
 		j[*h.Hostname] = h.IpAddress
@@ -727,10 +699,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsExtraHosts(ctx context.Context,
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsLinuxParametersDevices(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	if r.LinuxParameters == nil {
 		return nil
 	}
@@ -742,10 +711,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsLinuxParametersDevices(ctx cont
 	return resource.Set(c.Name, data)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsLinuxParametersTmpfs(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	if r.LinuxParameters == nil {
 		return nil
 	}
@@ -757,10 +723,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsLinuxParametersTmpfs(ctx contex
 	return resource.Set(c.Name, data)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsLogConfigurationSecretOptions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	if r.LogConfiguration == nil {
 		return nil
@@ -771,10 +734,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsLogConfigurationSecretOptions(c
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsMountPoints(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 
 	data, err := json.Marshal(r.MountPoints)
 	if err != nil {
@@ -783,10 +743,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsMountPoints(ctx context.Context
 	return resource.Set(c.Name, data)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsPortMappings(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	data, err := json.Marshal(r.PortMappings)
 	if err != nil {
 		return diag.WrapError(err)
@@ -794,10 +751,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsPortMappings(ctx context.Contex
 	return resource.Set(c.Name, data)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsResourceRequirements(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	if r.LogConfiguration == nil {
 		return nil
@@ -808,10 +762,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsResourceRequirements(ctx contex
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsSecrets(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	if r.LogConfiguration == nil {
 		return nil
@@ -822,10 +773,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsSecrets(ctx context.Context, me
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsSystemControls(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	if r.LogConfiguration == nil {
 		return nil
@@ -836,10 +784,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsSystemControls(ctx context.Cont
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsUlimits(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 
 	data, err := json.Marshal(r.Ulimits)
 	if err != nil {
@@ -848,10 +793,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsUlimits(ctx context.Context, me
 	return resource.Set(c.Name, data)
 }
 func resolveEcsTaskDefinitionContainerDefinitionsVolumesFrom(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ContainerDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.ContainerDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.ContainerDefinition)
 	j := map[string]interface{}{}
 	if r.LogConfiguration == nil {
 		return nil
@@ -862,19 +804,13 @@ func resolveEcsTaskDefinitionContainerDefinitionsVolumesFrom(ctx context.Context
 	return resource.Set(c.Name, j)
 }
 func fetchEcsTaskDefinitionVolumes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", parent.Item)
-	}
+	r := parent.Item.(types.TaskDefinition)
 	res <- r.Volumes
 	return nil
 }
 
 func resolveEcsTaskDefinitionTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.TaskDefinition)
-	if !ok {
-		return fmt.Errorf("expected to have types.TaskDefinition but got %T", resource.Item)
-	}
+	r := resource.Item.(types.TaskDefinition)
 
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ECS

--- a/resources/services/efs/filesystems.go
+++ b/resources/services/efs/filesystems.go
@@ -2,7 +2,6 @@ package efs
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
@@ -176,10 +175,7 @@ func fetchEfsFilesystems(ctx context.Context, meta schema.ClientMeta, parent *sc
 	return nil
 }
 func ResolveEfsFilesystemBackupPolicyStatus(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.FileSystemDescription)
-	if !ok {
-		return fmt.Errorf("expected types.FileSystemDescription but got %T", resource.Item)
-	}
+	p := resource.Item.(types.FileSystemDescription)
 	config := efs.DescribeBackupPolicyInput{
 		FileSystemId: p.FileSystemId,
 	}

--- a/resources/services/elasticbeanstalk/environments.go
+++ b/resources/services/elasticbeanstalk/environments.go
@@ -416,10 +416,7 @@ func fetchElasticbeanstalkEnvironments(ctx context.Context, meta schema.ClientMe
 	return nil
 }
 func resolveElasticbeanstalkEnvironmentTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.EnvironmentDescription)
-	if !ok {
-		return fmt.Errorf("expected types.EnvironmentDescription but got %T", resource.Item)
-	}
+	p := resource.Item.(types.EnvironmentDescription)
 	if p.Resources == nil || p.Resources.LoadBalancer == nil {
 		return nil
 	}
@@ -430,10 +427,7 @@ func resolveElasticbeanstalkEnvironmentTags(ctx context.Context, meta schema.Cli
 	return resource.Set(c.Name, listeners)
 }
 func resolveElasticbeanstalkEnvironmentListeners(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.EnvironmentDescription)
-	if !ok {
-		return fmt.Errorf("expected types.EnvironmentDescription but got %T", resource.Item)
-	}
+	p := resource.Item.(types.EnvironmentDescription)
 	svc := meta.(*client.Client).Services().ElasticBeanstalk
 	tagsOutput, err := svc.ListTagsForResource(ctx, &elasticbeanstalk.ListTagsForResourceInput{
 		ResourceArn: p.EnvironmentArn,
@@ -451,19 +445,13 @@ func resolveElasticbeanstalkEnvironmentListeners(ctx context.Context, meta schem
 	return resource.Set(c.Name, tags)
 }
 func fetchElasticbeanstalkEnvironmentLinks(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.EnvironmentDescription)
-	if !ok {
-		return fmt.Errorf("expected types.EnvironmentDescription but got %T", parent.Item)
-	}
+	p := parent.Item.(types.EnvironmentDescription)
 	res <- p.EnvironmentLinks
 	return nil
 }
 
 func fetchElasticbeanstalkConfigurationOptions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.EnvironmentDescription)
-	if !ok {
-		return fmt.Errorf("expected types.EnvironmentDescription but got %T", parent.Item)
-	}
+	p := parent.Item.(types.EnvironmentDescription)
 	c := meta.(*client.Client)
 	svc := c.Services().ElasticBeanstalk
 	configOptionsIn := elasticbeanstalk.DescribeConfigurationOptionsInput{
@@ -492,10 +480,7 @@ type ConfigOptions struct {
 }
 
 func fetchElasticbeanstalkConfigurationSettings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.EnvironmentDescription)
-	if !ok {
-		return fmt.Errorf("expected types.EnvironmentDescription but got %T", parent.Item)
-	}
+	p := parent.Item.(types.EnvironmentDescription)
 	c := meta.(*client.Client)
 	svc := c.Services().ElasticBeanstalk
 

--- a/resources/services/elasticsearch/domains.go
+++ b/resources/services/elasticsearch/domains.go
@@ -2,7 +2,6 @@ package elasticsearch
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go-v2/service/elasticsearchservice/types"
@@ -456,10 +455,7 @@ func fetchElasticsearchDomains(ctx context.Context, meta schema.ClientMeta, pare
 func resolveElasticsearchDomainTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ElasticSearch
-	domain, ok := resource.Item.(*types.ElasticsearchDomainStatus)
-	if !ok {
-		return fmt.Errorf("expected to have *types.ElasticsearchDomainStatus but got %T", resource.Item)
-	}
+	domain := resource.Item.(*types.ElasticsearchDomainStatus)
 	tagsOutput, err := svc.ListTags(ctx, &elasticsearchservice.ListTagsInput{
 		ARN: domain.ARN,
 	}, func(o *elasticsearchservice.Options) {

--- a/resources/services/elbv1/load_balancers.go
+++ b/resources/services/elbv1/load_balancers.go
@@ -2,7 +2,6 @@ package elbv1
 
 import (
 	"context"
-	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv1 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
@@ -462,50 +461,35 @@ func fetchElbv1LoadBalancers(ctx context.Context, meta schema.ClientMeta, parent
 	return nil
 }
 func resolveElbv1loadBalancerAttributesAccessLogEnabled(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.AccessLog == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.AccessLog.Enabled)
 }
 func resolveElbv1loadBalancerAttributesAccessLogS3BucketName(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.AccessLog == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.AccessLog.S3BucketName)
 }
 func resolveElbv1loadBalancerAttributesAccessLogS3BucketPrefix(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.AccessLog == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.AccessLog.S3BucketPrefix)
 }
 func resolveElbv1loadBalancerAttributesAccessLogEmitInterval(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.AccessLog == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.AccessLog.EmitInterval)
 }
 func resolveElbv1loadBalancerAttributesConnectionSettingsIdleTimeout(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.ConnectionSettings == nil {
 		return nil
 	}
@@ -513,40 +497,28 @@ func resolveElbv1loadBalancerAttributesConnectionSettingsIdleTimeout(ctx context
 	return resource.Set(c.Name, r.Attributes.ConnectionSettings.IdleTimeout)
 }
 func resolveElbv1loadBalancerAttributesCrossZoneLoadBalancingEnabled(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.CrossZoneLoadBalancing == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.CrossZoneLoadBalancing.Enabled)
 }
 func resolveElbv1loadBalancerAttributesConnectionDrainingEnabled(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.ConnectionDraining == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.ConnectionDraining.Enabled)
 }
 func resolveElbv1loadBalancerAttributesConnectionDrainingTimeout(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil && r.Attributes.ConnectionDraining == nil {
 		return nil
 	}
 	return resource.Set(c.Name, r.Attributes.ConnectionDraining.Timeout)
 }
 func resolveElbv1loadBalancerAttributesAdditionalAttributes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	if r.Attributes == nil {
 		return nil
 	}
@@ -558,10 +530,7 @@ func resolveElbv1loadBalancerAttributesAdditionalAttributes(ctx context.Context,
 	return resource.Set(c.Name, response)
 }
 func resolveElbv1loadBalancerInstances(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := resource.Item.(ELBv1LoadBalancerWrapper)
 	response := make([]string, 0, len(r.Instances))
 	for _, i := range r.Instances {
 		response = append(response, *i.InstanceId)
@@ -569,26 +538,17 @@ func resolveElbv1loadBalancerInstances(ctx context.Context, meta schema.ClientMe
 	return resource.Set(c.Name, response)
 }
 func fetchElbv1LoadBalancerBackendServerDescriptions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := parent.Item.(ELBv1LoadBalancerWrapper)
 	res <- r.BackendServerDescriptions
 	return nil
 }
 func fetchElbv1LoadBalancerListeners(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := parent.Item.(ELBv1LoadBalancerWrapper)
 	res <- r.ListenerDescriptions
 	return nil
 }
 func fetchElbv1LoadBalancerPoliciesAppCookieStickinessPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := parent.Item.(ELBv1LoadBalancerWrapper)
 
 	if r.Policies == nil {
 		return nil
@@ -597,10 +557,7 @@ func fetchElbv1LoadBalancerPoliciesAppCookieStickinessPolicies(ctx context.Conte
 	return nil
 }
 func fetchElbv1LoadBalancerPoliciesLbCookieStickinessPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := parent.Item.(ELBv1LoadBalancerWrapper)
 
 	if r.Policies == nil {
 		return nil
@@ -609,10 +566,7 @@ func fetchElbv1LoadBalancerPoliciesLbCookieStickinessPolicies(ctx context.Contex
 	return nil
 }
 func fetchElbv1LoadBalancerPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(ELBv1LoadBalancerWrapper)
-	if !ok {
-		return errors.New("not load balancer")
-	}
+	r := parent.Item.(ELBv1LoadBalancerWrapper)
 	c := meta.(*client.Client)
 	svc := c.Services().ELBv1
 	response, err := svc.DescribeLoadBalancerPolicies(ctx, &elbv1.DescribeLoadBalancerPoliciesInput{LoadBalancerName: r.LoadBalancerName}, func(options *elbv1.Options) {
@@ -625,10 +579,7 @@ func fetchElbv1LoadBalancerPolicies(ctx context.Context, meta schema.ClientMeta,
 	return nil
 }
 func resolveElbv1loadBalancerPolicyPolicyAttributeDescriptions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.PolicyDescription)
-	if !ok {
-		return errors.New("not policy description")
-	}
+	r := resource.Item.(types.PolicyDescription)
 
 	response := make(map[string]interface{}, len(r.PolicyAttributeDescriptions))
 	for _, a := range r.PolicyAttributeDescriptions {

--- a/resources/services/elbv2/listeners.go
+++ b/resources/services/elbv2/listeners.go
@@ -2,7 +2,6 @@ package elbv2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -351,10 +350,7 @@ func Elbv2Listeners() *schema.Table {
 //                                               Table Resolver Functions
 // ====================================================================================================================
 func fetchElbv2Listeners(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	lb, ok := parent.Item.(types.LoadBalancer)
-	if !ok {
-		return fmt.Errorf("expected to have types.LoadBalancer but got %T", parent.Item)
-	}
+	lb := parent.Item.(types.LoadBalancer)
 	config := elbv2.DescribeListenersInput{
 		LoadBalancerArn: lb.LoadBalancerArn,
 	}
@@ -378,10 +374,7 @@ func fetchElbv2Listeners(ctx context.Context, meta schema.ClientMeta, parent *sc
 func resolveElbv2listenerTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ELBv2
-	listener, ok := resource.Item.(types.Listener)
-	if !ok {
-		return fmt.Errorf("expected to have types.Listener but got %T", resource.Item)
-	}
+	listener := resource.Item.(types.Listener)
 	tagsOutput, err := svc.DescribeTags(ctx, &elbv2.DescribeTagsInput{
 		ResourceArns: []string{
 			*listener.ListenerArn,
@@ -407,10 +400,7 @@ func resolveElbv2listenerTags(ctx context.Context, meta schema.ClientMeta, resou
 func fetchElbv2ListenerCertificates(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ELBv2
-	listener, ok := parent.Item.(types.Listener)
-	if !ok {
-		return fmt.Errorf("expected to have types.Listener but got %T", parent.Item)
-	}
+	listener := parent.Item.(types.Listener)
 	config := elbv2.DescribeListenerCertificatesInput{ListenerArn: listener.ListenerArn}
 	for {
 		response, err := svc.DescribeListenerCertificates(ctx, &config, func(options *elbv2.Options) {
@@ -429,18 +419,12 @@ func fetchElbv2ListenerCertificates(ctx context.Context, meta schema.ClientMeta,
 }
 
 func fetchElbv2ListenerDefaultActions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	listener, ok := parent.Item.(types.Listener)
-	if !ok {
-		return fmt.Errorf("expected to have types.Listener but got %T", parent.Item)
-	}
+	listener := parent.Item.(types.Listener)
 	res <- listener.DefaultActions
 	return nil
 }
 func fetchElbv2ListenerDefaultActionForwardConfigTargetGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	action, ok := parent.Item.(types.Action)
-	if !ok {
-		return fmt.Errorf("expected to have types.Action but got %T", parent.Item)
-	}
+	action := parent.Item.(types.Action)
 	if action.ForwardConfig == nil {
 		return nil
 	}

--- a/resources/services/elbv2/load_balancers.go
+++ b/resources/services/elbv2/load_balancers.go
@@ -3,7 +3,6 @@ package elbv2
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -313,10 +312,7 @@ func fetchElbv2LoadBalancers(ctx context.Context, meta schema.ClientMeta, parent
 	return nil
 }
 func resolveElbv2loadBalancerWebACLArn(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.LoadBalancer)
-	if !ok {
-		return fmt.Errorf("expected to have types.LoadBalancer but got %T", resource.Item)
-	}
+	p := resource.Item.(types.LoadBalancer)
 	// only application load balancer can have web acl arn
 	if p.Type != types.LoadBalancerTypeEnumApplication {
 		return nil
@@ -343,10 +339,7 @@ func resolveElbv2loadBalancerWebACLArn(ctx context.Context, meta schema.ClientMe
 func resolveElbv2loadBalancerTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ELBv2
-	loadBalancer, ok := resource.Item.(types.LoadBalancer)
-	if !ok {
-		return fmt.Errorf("expected to have types.LoadBalancer but got %T", resource.Item)
-	}
+	loadBalancer := resource.Item.(types.LoadBalancer)
 	tagsOutput, err := svc.DescribeTags(ctx, &elbv2.DescribeTagsInput{
 		ResourceArns: []string{
 			*loadBalancer.LoadBalancerArn,
@@ -400,10 +393,7 @@ type lbAttributes struct {
 }
 
 func fetchElbv2LoadBalancerAttributes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	lb, ok := parent.Item.(types.LoadBalancer)
-	if !ok {
-		return fmt.Errorf("not a LoadBalancer instance: %T", parent.Item)
-	}
+	lb := parent.Item.(types.LoadBalancer)
 	c := meta.(*client.Client)
 	svc := c.Services().ELBv2
 	result, err := svc.DescribeLoadBalancerAttributes(ctx, &elbv2.DescribeLoadBalancerAttributesInput{LoadBalancerArn: lb.LoadBalancerArn}, func(options *elbv2.Options) {

--- a/resources/services/elbv2/target_groups.go
+++ b/resources/services/elbv2/target_groups.go
@@ -2,7 +2,6 @@ package elbv2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -164,10 +163,7 @@ func fetchElbv2TargetGroups(ctx context.Context, meta schema.ClientMeta, parent 
 func resolveElbv2targetGroupTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ELBv2
-	targetGroup, ok := resource.Item.(types.TargetGroup)
-	if !ok {
-		return fmt.Errorf("expected to have types.TargetGroup but got %T", resource.Item)
-	}
+	targetGroup := resource.Item.(types.TargetGroup)
 	tagsOutput, err := svc.DescribeTags(ctx, &elbv2.DescribeTagsInput{
 		ResourceArns: []string{
 			*targetGroup.TargetGroupArn,

--- a/resources/services/emr/block_public_access_configs.go
+++ b/resources/services/emr/block_public_access_configs.go
@@ -3,7 +3,6 @@ package emr
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/emr"
 	"github.com/cloudquery/cq-provider-aws/client"
@@ -118,10 +117,7 @@ func fetchEmrBlockPublicAccessConfigs(ctx context.Context, meta schema.ClientMet
 }
 
 func resolveEmrBlockPublicAccessConfigConfigurations(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	out, ok := resource.Item.(*emr.GetBlockPublicAccessConfigurationOutput)
-	if !ok {
-		return fmt.Errorf("not an *emr.GetBlockPublicAccessConfigurationOutput: %T", resource.Item)
-	}
+	out := resource.Item.(*emr.GetBlockPublicAccessConfigurationOutput)
 	if out.BlockPublicAccessConfiguration == nil {
 		return nil
 	}
@@ -133,10 +129,7 @@ func resolveEmrBlockPublicAccessConfigConfigurations(ctx context.Context, meta s
 }
 
 func fetchEmrBlockPublicAccessConfigPermittedPublicSecurityGroupRuleRanges(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	out, ok := parent.Item.(*emr.GetBlockPublicAccessConfigurationOutput)
-	if !ok {
-		return fmt.Errorf("not an *emr.GetBlockPublicAccessConfigurationOutput: %T", parent.Item)
-	}
+	out := parent.Item.(*emr.GetBlockPublicAccessConfigurationOutput)
 	if out.BlockPublicAccessConfiguration == nil {
 		return nil
 	}

--- a/resources/services/emr/clusters.go
+++ b/resources/services/emr/clusters.go
@@ -3,7 +3,6 @@ package emr
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/emr"
@@ -361,10 +360,7 @@ func fetchEmrClusters(ctx context.Context, meta schema.ClientMeta, parent *schem
 
 func resolveEMRClusterJSONField(getter func(c *types.Cluster) interface{}) func(context.Context, schema.ClientMeta, *schema.Resource, schema.Column) error {
 	return func(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-		cl, ok := resource.Item.(*types.Cluster)
-		if !ok {
-			return fmt.Errorf("not a %T instance: %T", c, resource.Item)
-		}
+		cl := resource.Item.(*types.Cluster)
 		b, err := json.Marshal(getter(cl))
 		if err != nil {
 			return diag.WrapError(err)

--- a/resources/services/guardduty/detectors.go
+++ b/resources/services/guardduty/detectors.go
@@ -2,7 +2,6 @@ package guardduty
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
@@ -192,10 +191,7 @@ func fetchGuarddutyDetectors(ctx context.Context, meta schema.ClientMeta, parent
 }
 
 func fetchGuarddutyDetectorMembers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	detector, ok := parent.Item.(Detector)
-	if !ok {
-		return fmt.Errorf("expected type *guardduty.GetDetectorOutput got %T", parent.Item)
-	}
+	detector := parent.Item.(Detector)
 	c := meta.(*client.Client)
 	svc := c.Services().GuardDuty
 	config := &guardduty.ListMembersInput{DetectorId: aws.String(detector.Id)}

--- a/resources/services/iam/group_policies.go
+++ b/resources/services/iam/group_policies.go
@@ -3,7 +3,6 @@ package iam
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -96,10 +95,7 @@ func fetchIamGroupPolicies(ctx context.Context, meta schema.ClientMeta, parent *
 	return nil
 }
 func resolveIamGroupPolicyPolicyDocument(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*iam.GetGroupPolicyOutput)
-	if !ok {
-		return fmt.Errorf("not group policy")
-	}
+	r := resource.Item.(*iam.GetGroupPolicyOutput)
 
 	decodedDocument, err := url.QueryUnescape(*r.PolicyDocument)
 	if err != nil {

--- a/resources/services/iam/openid_connect_identity_providers.go
+++ b/resources/services/iam/openid_connect_identity_providers.go
@@ -2,7 +2,6 @@ package iam
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/cloudquery/cq-provider-aws/client"
@@ -84,10 +83,7 @@ func fetchIamOpenidConnectIdentityProviders(ctx context.Context, meta schema.Cli
 	return nil
 }
 func resolveIamOpenidConnectIdentityProviderTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(IamOpenIdIdentityProviderWrapper)
-	if !ok {
-		return fmt.Errorf("not iam IamOpenIdIdentityProviderWrapper")
-	}
+	r := resource.Item.(IamOpenIdIdentityProviderWrapper)
 	response := make(map[string]interface{}, len(r.Tags))
 	for _, t := range r.Tags {
 		response[*t.Key] = t.Value

--- a/resources/services/iam/role_policies.go
+++ b/resources/services/iam/role_policies.go
@@ -3,7 +3,6 @@ package iam
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -93,10 +92,7 @@ func fetchIamRolePolicies(ctx context.Context, meta schema.ClientMeta, parent *s
 	return nil
 }
 func resolveIamRolePolicyPolicyDocument(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*iam.GetRolePolicyOutput)
-	if !ok {
-		return fmt.Errorf("not role policy")
-	}
+	r := resource.Item.(*iam.GetRolePolicyOutput)
 
 	decodedDocument, err := url.QueryUnescape(*r.PolicyDocument)
 	if err != nil {

--- a/resources/services/iam/saml_identity_providers.go
+++ b/resources/services/iam/saml_identity_providers.go
@@ -2,7 +2,6 @@ package iam
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/cloudquery/cq-provider-aws/client"
@@ -77,10 +76,7 @@ func fetchIamSamlIdentityProviders(ctx context.Context, meta schema.ClientMeta, 
 	return nil
 }
 func resolveIamSamlIdentityProviderTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(IamSamlIdentityProviderWrapper)
-	if !ok {
-		return fmt.Errorf("not iam identity provider")
-	}
+	r := resource.Item.(IamSamlIdentityProviderWrapper)
 	response := make(map[string]interface{}, len(r.Tags))
 	for _, t := range r.Tags {
 		response[*t.Key] = t.Value

--- a/resources/services/iam/user_policies.go
+++ b/resources/services/iam/user_policies.go
@@ -3,7 +3,6 @@ package iam
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -96,10 +95,7 @@ func fetchIamUserPolicies(ctx context.Context, meta schema.ClientMeta, parent *s
 	return nil
 }
 func resolveIamUserPolicyPolicyDocument(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*iam.GetUserPolicyOutput)
-	if !ok {
-		return fmt.Errorf("not user policy")
-	}
+	r := resource.Item.(*iam.GetUserPolicyOutput)
 
 	decodedDocument, err := url.QueryUnescape(*r.PolicyDocument)
 	if err != nil {

--- a/resources/services/iot/iot_billing_groups.go
+++ b/resources/services/iot/iot_billing_groups.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -123,10 +122,7 @@ func fetchIotBillingGroups(ctx context.Context, meta schema.ClientMeta, parent *
 	return nil
 }
 func ResolveIotBillingGroupThingsInGroup(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeBillingGroupOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeBillingGroupOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeBillingGroupOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListThingsInBillingGroupInput{
@@ -153,10 +149,7 @@ func ResolveIotBillingGroupThingsInGroup(ctx context.Context, meta schema.Client
 	return resource.Set(c.Name, things)
 }
 func ResolveIotBillingGroupTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeBillingGroupOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeBillingGroupOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeBillingGroupOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{

--- a/resources/services/iot/iot_ca_certificates.go
+++ b/resources/services/iot/iot_ca_certificates.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -147,10 +146,7 @@ func fetchIotCaCertificates(ctx context.Context, meta schema.ClientMeta, parent 
 	return nil
 }
 func ResolveIotCaCertificateCertificates(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*types.CACertificateDescription)
-	if !ok {
-		return fmt.Errorf("expected types.CACertificateDescription but got %T", resource.Item)
-	}
+	i := resource.Item.(*types.CACertificateDescription)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListCertificatesByCAInput{

--- a/resources/services/iot/iot_certificates.go
+++ b/resources/services/iot/iot_certificates.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -196,10 +195,7 @@ func fetchIotCertificates(ctx context.Context, meta schema.ClientMeta, parent *s
 	return nil
 }
 func ResolveIotCertificatePolicies(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*types.CertificateDescription)
-	if !ok {
-		return fmt.Errorf("expected *types.CertificateDescription but got %T", resource.Item)
-	}
+	i := resource.Item.(*types.CertificateDescription)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListAttachedPoliciesInput{

--- a/resources/services/iot/iot_jobs.go
+++ b/resources/services/iot/iot_jobs.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -297,10 +296,7 @@ func fetchIotJobs(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 	return nil
 }
 func ResolveIotJobTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*types.Job)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*types.Job)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{
@@ -327,10 +323,7 @@ func ResolveIotJobTags(ctx context.Context, meta schema.ClientMeta, resource *sc
 	return resource.Set(c.Name, tags)
 }
 func fetchIotJobAbortConfigCriteriaLists(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	i, ok := parent.Item.(*types.Job)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", parent.Item)
-	}
+	i := parent.Item.(*types.Job)
 	if i.AbortConfig == nil {
 		return nil
 	}

--- a/resources/services/iot/iot_policies.go
+++ b/resources/services/iot/iot_policies.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -120,10 +119,7 @@ func fetchIotPolicies(ctx context.Context, meta schema.ClientMeta, parent *schem
 	return nil
 }
 func ResolveIotPolicyTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.GetPolicyOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.GetPolicyOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{

--- a/resources/services/iot/iot_security_profiles.go
+++ b/resources/services/iot/iot_security_profiles.go
@@ -3,7 +3,6 @@ package iot
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -222,10 +221,7 @@ func fetchIotSecurityProfiles(ctx context.Context, meta schema.ClientMeta, paren
 	return nil
 }
 func ResolveIotSecurityProfileTargets(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeSecurityProfileOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeSecurityProfileOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTargetsForSecurityProfileInput{
@@ -254,10 +250,7 @@ func ResolveIotSecurityProfileTargets(ctx context.Context, meta schema.ClientMet
 	return resource.Set(c.Name, targets)
 }
 func ResolveIotSecurityProfileTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeSecurityProfileOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeSecurityProfileOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{
@@ -284,10 +277,7 @@ func ResolveIotSecurityProfileTags(ctx context.Context, meta schema.ClientMeta, 
 	return resource.Set(c.Name, tags)
 }
 func resolveIotSecurityProfilesAdditionalMetricsToRetainV2(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeSecurityProfileOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeSecurityProfileOutput)
 
 	if i.AdditionalMetricsToRetainV2 == nil {
 		return nil
@@ -300,10 +290,7 @@ func resolveIotSecurityProfilesAdditionalMetricsToRetainV2(ctx context.Context, 
 	return resource.Set(c.Name, b)
 }
 func fetchIotSecurityProfileBehaviors(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	i, ok := parent.Item.(*iot.DescribeSecurityProfileOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeSecurityProfileOutput but got %T", parent.Item)
-	}
+	i := parent.Item.(*iot.DescribeSecurityProfileOutput)
 	if i.Behaviors == nil {
 		return nil
 	}
@@ -312,10 +299,7 @@ func fetchIotSecurityProfileBehaviors(ctx context.Context, meta schema.ClientMet
 	return nil
 }
 func resolveIotSecurityProfileBehaviorsCriteriaValue(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(types.Behavior)
-	if !ok {
-		return fmt.Errorf("expected types.Behavior but got %T", resource.Item)
-	}
+	i := resource.Item.(types.Behavior)
 	if i.Criteria == nil || i.Criteria.Value == nil {
 		return nil
 	}

--- a/resources/services/iot/iot_streams.go
+++ b/resources/services/iot/iot_streams.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -152,10 +151,7 @@ func fetchIotStreams(ctx context.Context, meta schema.ClientMeta, parent *schema
 	return nil
 }
 func fetchIotStreamFiles(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	i, ok := parent.Item.(*types.StreamInfo)
-	if !ok {
-		return fmt.Errorf("expected types.StreamSummary but got %T", parent.Item)
-	}
+	i := parent.Item.(*types.StreamInfo)
 
 	res <- i.Files
 	return nil

--- a/resources/services/iot/iot_thing_groups.go
+++ b/resources/services/iot/iot_thing_groups.go
@@ -3,7 +3,6 @@ package iot
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -177,10 +176,7 @@ func fetchIotThingGroups(ctx context.Context, meta schema.ClientMeta, parent *sc
 	return nil
 }
 func ResolveIotThingGroupThingsInGroup(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeThingGroupOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeThingGroupOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeThingGroupOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListThingsInThingGroupInput{
@@ -207,10 +203,7 @@ func ResolveIotThingGroupThingsInGroup(ctx context.Context, meta schema.ClientMe
 	return resource.Set(c.Name, things)
 }
 func ResolveIotThingGroupPolicies(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeThingGroupOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeThingGroupOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeThingGroupOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListAttachedPoliciesInput{
@@ -239,10 +232,7 @@ func ResolveIotThingGroupPolicies(ctx context.Context, meta schema.ClientMeta, r
 	return resource.Set(c.Name, policies)
 }
 func ResolveIotThingGroupTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeThingGroupOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeThingGroupOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeThingGroupOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{
@@ -269,10 +259,7 @@ func ResolveIotThingGroupTags(ctx context.Context, meta schema.ClientMeta, resou
 	return resource.Set(c.Name, tags)
 }
 func resolveIotThingGroupsRootToParentThingGroups(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.DescribeThingGroupOutput)
-	if !ok {
-		return fmt.Errorf("expected *iot.DescribeThingGroupOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.DescribeThingGroupOutput)
 	if i.ThingGroupMetadata == nil {
 		return nil
 	}

--- a/resources/services/iot/iot_thing_types.go
+++ b/resources/services/iot/iot_thing_types.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -118,10 +117,7 @@ func fetchIotThingTypes(ctx context.Context, meta schema.ClientMeta, parent *sch
 	return nil
 }
 func ResolveIotThingTypeTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(types.ThingTypeDefinition)
-	if !ok {
-		return fmt.Errorf("expected types.ThingTypeDefinition but got %T", resource.Item)
-	}
+	i := resource.Item.(types.ThingTypeDefinition)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{

--- a/resources/services/iot/iot_things.go
+++ b/resources/services/iot/iot_things.go
@@ -2,7 +2,6 @@ package iot
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -100,10 +99,7 @@ func fetchIotThings(ctx context.Context, meta schema.ClientMeta, parent *schema.
 	return nil
 }
 func ResolveIotThingPrincipals(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(types.ThingAttribute)
-	if !ok {
-		return fmt.Errorf("expected types.ThingAttribute but got %T", resource.Item)
-	}
+	i := resource.Item.(types.ThingAttribute)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListThingPrincipalsInput{

--- a/resources/services/iot/iot_topic_rules.go
+++ b/resources/services/iot/iot_topic_rules.go
@@ -3,7 +3,6 @@ package iot
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iot"
@@ -1339,10 +1338,7 @@ func fetchIotTopicRules(ctx context.Context, meta schema.ClientMeta, parent *sch
 	return nil
 }
 func ResolveIotTopicRuleTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.GetTopicRuleOutput)
-	if !ok {
-		return fmt.Errorf("expected  *iot.GetTopicRuleOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.GetTopicRuleOutput)
 	client := meta.(*client.Client)
 	svc := client.Services().IOT
 	input := iot.ListTagsForResourceInput{
@@ -1369,10 +1365,7 @@ func ResolveIotTopicRuleTags(ctx context.Context, meta schema.ClientMeta, resour
 	return resource.Set(c.Name, tags)
 }
 func resolveIotTopicRulesErrorActionHttpHeaders(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.GetTopicRuleOutput)
-	if !ok {
-		return fmt.Errorf("expected  *iot.GetTopicRuleOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.GetTopicRuleOutput)
 	if i.Rule == nil || i.Rule.ErrorAction == nil || i.Rule.ErrorAction.Http == nil {
 		return nil
 	}
@@ -1383,10 +1376,7 @@ func resolveIotTopicRulesErrorActionHttpHeaders(ctx context.Context, meta schema
 	return resource.Set(c.Name, j)
 }
 func resolveIotTopicRulesErrorActionIotSiteWise(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.GetTopicRuleOutput)
-	if !ok {
-		return fmt.Errorf("expected  *types.Action but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.GetTopicRuleOutput)
 	if i.Rule == nil || i.Rule.ErrorAction == nil || i.Rule.ErrorAction.IotSiteWise == nil {
 		return nil
 	}
@@ -1397,10 +1387,7 @@ func resolveIotTopicRulesErrorActionIotSiteWise(ctx context.Context, meta schema
 	return resource.Set(c.Name, b)
 }
 func resolveIotTopicRulesErrorActionTimestreamDimensions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(*iot.GetTopicRuleOutput)
-	if !ok {
-		return fmt.Errorf("expected  *iot.GetTopicRuleOutput but got %T", resource.Item)
-	}
+	i := resource.Item.(*iot.GetTopicRuleOutput)
 	if i.Rule == nil || i.Rule.ErrorAction == nil || i.Rule.ErrorAction.Timestream == nil {
 		return nil
 	}
@@ -1411,10 +1398,7 @@ func resolveIotTopicRulesErrorActionTimestreamDimensions(ctx context.Context, me
 	return resource.Set(c.Name, j)
 }
 func fetchIotTopicRuleActions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	i, ok := parent.Item.(*iot.GetTopicRuleOutput)
-	if !ok {
-		return fmt.Errorf("expected  *iot.GetTopicRuleOutput but got %T", parent.Item)
-	}
+	i := parent.Item.(*iot.GetTopicRuleOutput)
 	if i.Rule == nil {
 		return nil
 	}
@@ -1422,10 +1406,7 @@ func fetchIotTopicRuleActions(ctx context.Context, meta schema.ClientMeta, paren
 	return nil
 }
 func resolveIotTopicRuleActionsHttpHeaders(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(types.Action)
-	if !ok {
-		return fmt.Errorf("expected  *types.Action but got %T", resource.Item)
-	}
+	i := resource.Item.(types.Action)
 	if i.Http == nil {
 		return nil
 	}
@@ -1436,10 +1417,7 @@ func resolveIotTopicRuleActionsHttpHeaders(ctx context.Context, meta schema.Clie
 	return resource.Set(c.Name, j)
 }
 func resolveIotTopicRuleActionsIotSiteWise(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(types.Action)
-	if !ok {
-		return fmt.Errorf("expected  *types.Action but got %T", resource.Item)
-	}
+	i := resource.Item.(types.Action)
 	if i.IotSiteWise == nil {
 		return nil
 	}
@@ -1450,10 +1428,7 @@ func resolveIotTopicRuleActionsIotSiteWise(ctx context.Context, meta schema.Clie
 	return resource.Set(c.Name, b)
 }
 func resolveIotTopicRuleActionsTimestreamDimensions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	i, ok := resource.Item.(types.Action)
-	if !ok {
-		return fmt.Errorf("expected  *types.Action but got %T", resource.Item)
-	}
+	i := resource.Item.(types.Action)
 	if i.Timestream == nil {
 		return nil
 	}

--- a/resources/services/kms/keys.go
+++ b/resources/services/kms/keys.go
@@ -2,7 +2,6 @@ package kms
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -164,10 +163,7 @@ func fetchKmsKeys(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 	return nil
 }
 func resolveKmsKey(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
-	r, ok := resource.Item.(types.KeyListEntry)
-	if !ok {
-		return fmt.Errorf("expected types.KeyListEntry but got %T", resource.Item)
-	}
+	r := resource.Item.(types.KeyListEntry)
 	c := meta.(*client.Client)
 	svc := c.Services().KMS
 	output, err := svc.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: r.KeyId}, func(options *kms.Options) {

--- a/resources/services/lambda/functions.go
+++ b/resources/services/lambda/functions.go
@@ -3,7 +3,6 @@ package lambda
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -1011,10 +1010,7 @@ func fetchLambdaFunctions(ctx context.Context, meta schema.ClientMeta, parent *s
 	return nil
 }
 func resolvePolicyCodeSigningConfig(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
-	r, ok := resource.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", r)
-	}
+	r := resource.Item.(*lambda.GetFunctionOutput)
 	if r.Configuration == nil {
 		return nil
 	}
@@ -1109,10 +1105,7 @@ func resolvePolicyCodeSigningConfig(ctx context.Context, meta schema.ClientMeta,
 	return nil
 }
 func fetchLambdaFunctionFileSystemConfigs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", r)
-	}
+	r := parent.Item.(*lambda.GetFunctionOutput)
 	if r.Configuration == nil {
 		return nil
 	}
@@ -1121,10 +1114,7 @@ func fetchLambdaFunctionFileSystemConfigs(ctx context.Context, meta schema.Clien
 	return nil
 }
 func fetchLambdaFunctionLayers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", r)
-	}
+	r := parent.Item.(*lambda.GetFunctionOutput)
 	if r.Configuration == nil {
 		return nil
 	}
@@ -1133,10 +1123,7 @@ func fetchLambdaFunctionLayers(ctx context.Context, meta schema.ClientMeta, pare
 	return nil
 }
 func fetchLambdaFunctionAliases(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", p)
-	}
+	p := parent.Item.(*lambda.GetFunctionOutput)
 	if p.Configuration == nil {
 		return nil
 	}
@@ -1167,10 +1154,7 @@ func fetchLambdaFunctionAliases(ctx context.Context, meta schema.ClientMeta, par
 	return nil
 }
 func fetchLambdaFunctionEventInvokeConfigs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", p)
-	}
+	p := parent.Item.(*lambda.GetFunctionOutput)
 	if p.Configuration == nil {
 		return nil
 	}
@@ -1193,10 +1177,7 @@ func fetchLambdaFunctionEventInvokeConfigs(ctx context.Context, meta schema.Clie
 	return nil
 }
 func fetchLambdaFunctionVersions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", p)
-	}
+	p := parent.Item.(*lambda.GetFunctionOutput)
 	if p.Configuration == nil {
 		return nil
 	}
@@ -1220,28 +1201,19 @@ func fetchLambdaFunctionVersions(ctx context.Context, meta schema.ClientMeta, pa
 	return nil
 }
 func fetchLambdaFunctionVersionFileSystemConfigs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.FunctionConfiguration)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of FunctionConfiguration", r)
-	}
+	r := parent.Item.(types.FunctionConfiguration)
 
 	res <- r.FileSystemConfigs
 	return nil
 }
 func fetchLambdaFunctionVersionLayers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.FunctionConfiguration)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of FunctionConfiguration", r)
-	}
+	r := parent.Item.(types.FunctionConfiguration)
 
 	res <- r.Layers
 	return nil
 }
 func fetchLambdaFunctionConcurrencyConfigs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", p)
-	}
+	p := parent.Item.(*lambda.GetFunctionOutput)
 	if p.Configuration == nil {
 		return nil
 	}
@@ -1265,10 +1237,7 @@ func fetchLambdaFunctionConcurrencyConfigs(ctx context.Context, meta schema.Clie
 	return nil
 }
 func fetchLambdaFunctionEventSourceMappings(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(*lambda.GetFunctionOutput)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of *GetFunctionOutput", p)
-	}
+	p := parent.Item.(*lambda.GetFunctionOutput)
 	if p.Configuration == nil {
 		return nil
 	}
@@ -1292,10 +1261,7 @@ func fetchLambdaFunctionEventSourceMappings(ctx context.Context, meta schema.Cli
 	return nil
 }
 func resolveLambdaFunctionEventSourceMappingAccessConfigurations(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	p, ok := resource.Item.(types.EventSourceMappingConfiguration)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of EventSourceMappingConfiguration", p)
-	}
+	p := resource.Item.(types.EventSourceMappingConfiguration)
 	if len(p.SourceAccessConfigurations) == 0 {
 		return nil
 	}

--- a/resources/services/lambda/layers.go
+++ b/resources/services/lambda/layers.go
@@ -2,7 +2,6 @@ package lambda
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -192,10 +191,7 @@ func fetchLambdaLayers(ctx context.Context, meta schema.ClientMeta, parent *sche
 	return nil
 }
 func fetchLambdaLayerVersions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.LayersListItem)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of LayersListItem", p)
-	}
+	p := parent.Item.(types.LayersListItem)
 	svc := meta.(*client.Client).Services().Lambda
 	config := lambda.ListLayerVersionsInput{
 		LayerName: p.LayerName,
@@ -215,15 +211,9 @@ func fetchLambdaLayerVersions(ctx context.Context, meta schema.ClientMeta, paren
 	return nil
 }
 func fetchLambdaLayerVersionPolicies(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	p, ok := parent.Item.(types.LayerVersionsListItem)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of LayerVersionsListItem", p)
-	}
+	p := parent.Item.(types.LayerVersionsListItem)
 
-	pp, ok := parent.Parent.Item.(types.LayersListItem)
-	if !ok {
-		return fmt.Errorf("wrong type assertion: got %T instead of LayersListItem", p)
-	}
+	pp := parent.Parent.Item.(types.LayersListItem)
 	c := meta.(*client.Client)
 	svc := c.Services().Lambda
 

--- a/resources/services/mq/brokers.go
+++ b/resources/services/mq/brokers.go
@@ -3,7 +3,6 @@ package mq
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mq"
@@ -360,10 +359,7 @@ func fetchMqBrokers(ctx context.Context, meta schema.ClientMeta, parent *schema.
 }
 
 func resolveMqBrokerBrokerInstances(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	broker, ok := resource.Item.(*mq.DescribeBrokerOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeBrokerOutput instance: %#v", resource.Item)
-	}
+	broker := resource.Item.(*mq.DescribeBrokerOutput)
 	data, err := json.Marshal(broker.BrokerInstances)
 	if err != nil {
 		return diag.WrapError(err)
@@ -372,10 +368,7 @@ func resolveMqBrokerBrokerInstances(ctx context.Context, meta schema.ClientMeta,
 }
 
 func resolveMqBrokerLdapServerMetadata(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	broker, ok := resource.Item.(*mq.DescribeBrokerOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeBrokerOutput instance: %#v", resource.Item)
-	}
+	broker := resource.Item.(*mq.DescribeBrokerOutput)
 	data, err := json.Marshal(broker.LdapServerMetadata)
 	if err != nil {
 		return diag.WrapError(err)
@@ -384,10 +377,7 @@ func resolveMqBrokerLdapServerMetadata(ctx context.Context, meta schema.ClientMe
 }
 
 func resolveMqBrokerLogs(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	broker, ok := resource.Item.(*mq.DescribeBrokerOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeBrokerOutput instance: %#v", resource.Item)
-	}
+	broker := resource.Item.(*mq.DescribeBrokerOutput)
 	data, err := json.Marshal(broker.Logs)
 	if err != nil {
 		return diag.WrapError(err)
@@ -396,10 +386,7 @@ func resolveMqBrokerLogs(ctx context.Context, meta schema.ClientMeta, resource *
 }
 
 func resolveMqBrokerMaintenanceWindowStartTime(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	broker, ok := resource.Item.(*mq.DescribeBrokerOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeBrokerOutput instance: %#v", resource.Item)
-	}
+	broker := resource.Item.(*mq.DescribeBrokerOutput)
 	data, err := json.Marshal(broker.MaintenanceWindowStartTime)
 	if err != nil {
 		return diag.WrapError(err)
@@ -408,10 +395,7 @@ func resolveMqBrokerMaintenanceWindowStartTime(ctx context.Context, meta schema.
 }
 
 func resolveMqBrokerPendingLdapServerMetadata(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	broker, ok := resource.Item.(*mq.DescribeBrokerOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeBrokerOutput instance: %#v", resource.Item)
-	}
+	broker := resource.Item.(*mq.DescribeBrokerOutput)
 	data, err := json.Marshal(broker.PendingLdapServerMetadata)
 	if err != nil {
 		return diag.WrapError(err)
@@ -479,10 +463,7 @@ func fetchMqBrokerUsers(ctx context.Context, meta schema.ClientMeta, parent *sch
 }
 
 func resolveMqBrokerUserPending(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	user, ok := resource.Item.(*mq.DescribeUserOutput)
-	if !ok {
-		return fmt.Errorf("not a DescribeUserOutput instance: %#v", resource.Item)
-	}
+	user := resource.Item.(*mq.DescribeUserOutput)
 	data, err := json.Marshal(user.Pending)
 	if err != nil {
 		return diag.WrapError(err)

--- a/resources/services/rds/cluster_snapshots.go
+++ b/resources/services/rds/cluster_snapshots.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -187,10 +186,7 @@ func fetchRdsClusterSnapshots(ctx context.Context, meta schema.ClientMeta, paren
 }
 
 func resolveRDSClusterSnapshotTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	s, ok := resource.Item.(types.DBClusterSnapshot)
-	if !ok {
-		return fmt.Errorf("not a types.DBClusterSnapshot: %T", resource.Item)
-	}
+	s := resource.Item.(types.DBClusterSnapshot)
 	tags := map[string]*string{}
 	for _, t := range s.TagList {
 		tags[*t.Key] = t.Value
@@ -199,10 +195,7 @@ func resolveRDSClusterSnapshotTags(ctx context.Context, meta schema.ClientMeta, 
 }
 
 func resolveRDSClusterSnapshotAttributes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, column schema.Column) error {
-	s, ok := resource.Item.(types.DBClusterSnapshot)
-	if !ok {
-		return fmt.Errorf("not a types.DBClusterSnapshot: %T", resource.Item)
-	}
+	s := resource.Item.(types.DBClusterSnapshot)
 	c := meta.(*client.Client)
 	svc := c.Services().RDS
 	out, err := svc.DescribeDBClusterSnapshotAttributes(

--- a/resources/services/rds/clusters.go
+++ b/resources/services/rds/clusters.go
@@ -2,7 +2,6 @@ package rds
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -522,26 +521,17 @@ func resolveRdsClusterTags(ctx context.Context, meta schema.ClientMeta, resource
 	return resource.Set("tags", tags)
 }
 func fetchRdsClusterAssociatedRoles(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.DBCluster)
-	if !ok {
-		return fmt.Errorf("not db cluster")
-	}
+	cluster := parent.Item.(types.DBCluster)
 	res <- cluster.AssociatedRoles
 	return nil
 }
 func fetchRdsClusterDbClusterMembers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.DBCluster)
-	if !ok {
-		return fmt.Errorf("not db cluster")
-	}
+	cluster := parent.Item.(types.DBCluster)
 	res <- cluster.DBClusterMembers
 	return nil
 }
 func resolveRdsClusterDbClusterOptionGroupMemberships(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	cluster, ok := resource.Item.(types.DBCluster)
-	if !ok {
-		return fmt.Errorf("not db cluster")
-	}
+	cluster := resource.Item.(types.DBCluster)
 	if cluster.DBClusterOptionGroupMemberships == nil {
 		return nil
 	}
@@ -553,18 +543,12 @@ func resolveRdsClusterDbClusterOptionGroupMemberships(ctx context.Context, meta 
 }
 
 func fetchRdsClusterDomainMemberships(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.DBCluster)
-	if !ok {
-		return fmt.Errorf("not db cluster")
-	}
+	cluster := parent.Item.(types.DBCluster)
 	res <- cluster.DomainMemberships
 	return nil
 }
 func fetchRdsClusterVpcSecurityGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.DBCluster)
-	if !ok {
-		return fmt.Errorf("not db cluster")
-	}
+	cluster := parent.Item.(types.DBCluster)
 	res <- cluster.VpcSecurityGroups
 	return nil
 }

--- a/resources/services/rds/db_snapshots.go
+++ b/resources/services/rds/db_snapshots.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -228,10 +227,7 @@ func fetchRdsDbSnapshots(ctx context.Context, meta schema.ClientMeta, parent *sc
 }
 
 func resolveRDSDBSnapshotTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	s, ok := resource.Item.(types.DBSnapshot)
-	if !ok {
-		return fmt.Errorf("not a types.DBSnapshot: %T", resource.Item)
-	}
+	s := resource.Item.(types.DBSnapshot)
 	tags := map[string]*string{}
 	for _, t := range s.TagList {
 		tags[*t.Key] = t.Value
@@ -240,10 +236,7 @@ func resolveRDSDBSnapshotTags(ctx context.Context, meta schema.ClientMeta, resou
 }
 
 func resolveRDSDBSnapshotAttributes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, column schema.Column) error {
-	s, ok := resource.Item.(types.DBSnapshot)
-	if !ok {
-		return fmt.Errorf("not a types.DBSnapshot: %T", resource.Item)
-	}
+	s := resource.Item.(types.DBSnapshot)
 	c := meta.(*client.Client)
 	svc := c.Services().RDS
 	out, err := svc.DescribeDBSnapshotAttributes(
@@ -268,10 +261,7 @@ func resolveRDSDBSnapshotAttributes(ctx context.Context, meta schema.ClientMeta,
 }
 
 func resolveRDSDBSnapshotProcessorFeatures(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, column schema.Column) error {
-	s, ok := resource.Item.(types.DBSnapshot)
-	if !ok {
-		return fmt.Errorf("not a types.DBSnapshot: %T", resource.Item)
-	}
+	s := resource.Item.(types.DBSnapshot)
 
 	b, err := json.Marshal(s.ProcessorFeatures)
 	if err != nil {

--- a/resources/services/rds/event_subscriptions.go
+++ b/resources/services/rds/event_subscriptions.go
@@ -2,7 +2,6 @@ package rds
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -120,10 +119,7 @@ func fetchRdsEventSubscriptions(ctx context.Context, meta schema.ClientMeta, par
 }
 
 func resolveRDSEventSubscriptionTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	s, ok := resource.Item.(types.EventSubscription)
-	if !ok {
-		return fmt.Errorf("not a %T: %T", s, resource.Item)
-	}
+	s := resource.Item.(types.EventSubscription)
 	cl := meta.(*client.Client)
 	svc := cl.Services().RDS
 	out, err := svc.ListTagsForResource(ctx, &rds.ListTagsForResourceInput{ResourceName: s.EventSubscriptionArn}, func(o *rds.Options) {

--- a/resources/services/rds/instances.go
+++ b/resources/services/rds/instances.go
@@ -3,7 +3,6 @@ package rds
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -802,66 +801,42 @@ func resolveRdsInstanceTags(ctx context.Context, meta schema.ClientMeta, resourc
 	return resource.Set(c.Name, tags)
 }
 func fetchRdsInstanceAssociatedRoles(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.AssociatedRoles
 	return nil
 }
 func fetchRdsInstanceDbInstanceAutomatedBackupsReplications(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.DBInstanceAutomatedBackupsReplications
 	return nil
 }
 func fetchRdsInstanceDbParameterGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.DBParameterGroups
 	return nil
 }
 func fetchRdsInstanceDbSecurityGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.DBSecurityGroups
 	return nil
 }
 func fetchRdsInstanceDbSubnetGroupSubnets(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.DBSubnetGroup.Subnets
 	return nil
 }
 func fetchRdsInstanceDomainMemberships(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.DomainMemberships
 	return nil
 }
 func fetchRdsInstanceOptionGroupMemberships(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.OptionGroupMemberships
 	return nil
 }
 func resolveRdsInstanceStatusInfos(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	instance, ok := resource.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := resource.Item.(types.DBInstance)
 	data, err := json.Marshal(instance.StatusInfos)
 	if err != nil {
 		return diag.WrapError(err)
@@ -869,10 +844,7 @@ func resolveRdsInstanceStatusInfos(ctx context.Context, meta schema.ClientMeta, 
 	return resource.Set(c.Name, data)
 }
 func fetchRdsInstanceVpcSecurityGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.DBInstance)
-	if !ok {
-		return fmt.Errorf("not instance")
-	}
+	instance := parent.Item.(types.DBInstance)
 	res <- instance.VpcSecurityGroups
 	return nil
 }

--- a/resources/services/rds/subnet_groups.go
+++ b/resources/services/rds/subnet_groups.go
@@ -2,7 +2,6 @@ package rds
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -129,10 +128,7 @@ func fetchRdsSubnetGroups(ctx context.Context, meta schema.ClientMeta, parent *s
 	return nil
 }
 func fetchRdsSubnetGroupSubnets(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	subnetGroup, ok := parent.Item.(types.DBSubnetGroup)
-	if !ok {
-		return fmt.Errorf("not db cluster")
-	}
+	subnetGroup := parent.Item.(types.DBSubnetGroup)
 	res <- subnetGroup.Subnets
 	return nil
 }

--- a/resources/services/redshift/clusters.go
+++ b/resources/services/redshift/clusters.go
@@ -2,7 +2,6 @@ package redshift
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
@@ -815,10 +814,7 @@ func fetchRedshiftClusters(ctx context.Context, meta schema.ClientMeta, parent *
 	return nil
 }
 func resolveRedshiftClusterTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("expected Cluster but got %T", r)
-	}
+	r := resource.Item.(types.Cluster)
 	tags := map[string]*string{}
 	for _, t := range r.Tags {
 		tags[*t.Key] = t.Value
@@ -826,10 +822,7 @@ func resolveRedshiftClusterTags(ctx context.Context, meta schema.ClientMeta, res
 	return resource.Set(c.Name, tags)
 }
 func resolveRedshiftClusterLoggingStatus(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("expected Cluster but got %T", r)
-	}
+	r := resource.Item.(types.Cluster)
 
 	cl := meta.(*client.Client)
 	svc := cl.Services().Redshift
@@ -846,26 +839,17 @@ func resolveRedshiftClusterLoggingStatus(ctx context.Context, meta schema.Client
 	return resource.Set(c.Name, response)
 }
 func fetchRedshiftClusterNodes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.ClusterNodes
 	return nil
 }
 func fetchRedshiftClusterParameterGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.ClusterParameterGroups
 	return nil
 }
 func fetchRedshiftClusterParameter(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	parameterGroup, ok := parent.Item.(types.ClusterParameterGroupStatus)
-	if !ok {
-		return fmt.Errorf("not redshift cluster parameter group")
-	}
+	parameterGroup := parent.Item.(types.ClusterParameterGroupStatus)
 	config := redshift.DescribeClusterParametersInput{
 		ParameterGroupName: parameterGroup.ParameterGroupName,
 	}
@@ -888,58 +872,37 @@ func fetchRedshiftClusterParameter(ctx context.Context, meta schema.ClientMeta, 
 	return nil
 }
 func fetchRedshiftClusterParameterGroupStatusLists(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	parameterGroup, ok := parent.Item.(types.ClusterParameterGroupStatus)
-	if !ok {
-		return fmt.Errorf("not redshift cluster parameter group")
-	}
+	parameterGroup := parent.Item.(types.ClusterParameterGroupStatus)
 	res <- parameterGroup.ClusterParameterStatusList
 	return nil
 }
 func fetchRedshiftClusterSecurityGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.ClusterSecurityGroups
 	return nil
 }
 func fetchRedshiftClusterDeferredMaintenanceWindows(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.DeferredMaintenanceWindows
 	return nil
 }
 func fetchRedshiftClusterEndpointVpcEndpoints(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.Endpoint.VpcEndpoints
 	return nil
 }
 func fetchRedshiftClusterEndpointVpcEndpointNetworkInterfaces(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	vpcEndpoint, ok := parent.Item.(types.VpcEndpoint)
-	if !ok {
-		return fmt.Errorf("not vpc endpoint")
-	}
+	vpcEndpoint := parent.Item.(types.VpcEndpoint)
 	res <- vpcEndpoint.NetworkInterfaces
 	return nil
 }
 func fetchRedshiftClusterIamRoles(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.IamRoles
 	return nil
 }
 func fetchRedshiftClusterVpcSecurityGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	cluster, ok := parent.Item.(types.Cluster)
-	if !ok {
-		return fmt.Errorf("not redshift cluster")
-	}
+	cluster := parent.Item.(types.Cluster)
 	res <- cluster.VpcSecurityGroups
 	return nil
 }

--- a/resources/services/redshift/subnet_groups.go
+++ b/resources/services/redshift/subnet_groups.go
@@ -2,7 +2,6 @@ package redshift
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
@@ -141,10 +140,7 @@ func resolveRedshiftSubnetGroupTags(ctx context.Context, meta schema.ClientMeta,
 	return resource.Set("tags", tags)
 }
 func fetchRedshiftSubnetGroupSubnets(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	clusterSubnetGroup, ok := parent.Item.(types.ClusterSubnetGroup)
-	if !ok {
-		return fmt.Errorf("not redshift cluster subnet group")
-	}
+	clusterSubnetGroup := parent.Item.(types.ClusterSubnetGroup)
 	res <- clusterSubnetGroup.Subnets
 	return nil
 }

--- a/resources/services/route53/domains.go
+++ b/resources/services/route53/domains.go
@@ -3,7 +3,6 @@ package route53
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53domains"
@@ -437,10 +436,7 @@ func fetchRoute53Domains(ctx context.Context, meta schema.ClientMeta, parent *sc
 }
 
 func fetchRoute53DomainNameservers(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	d, ok := parent.Item.(*route53domains.GetDomainDetailOutput)
-	if !ok {
-		return fmt.Errorf("not a *route53domains.GetDomainDetailOutput instance: %T", parent.Item)
-	}
+	d := parent.Item.(*route53domains.GetDomainDetailOutput)
 	res <- d.Nameservers
 	return nil
 }
@@ -448,10 +444,7 @@ func fetchRoute53DomainNameservers(ctx context.Context, meta schema.ClientMeta, 
 func resolveRoute53DomainTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, col schema.Column) error {
 	c := meta.(*client.Client)
 	svc := c.Services().Route53Domains
-	d, ok := resource.Item.(*route53domains.GetDomainDetailOutput)
-	if !ok {
-		return fmt.Errorf("not a *route53domains.GetDomainDetailOutput instance: %T", resource.Item)
-	}
+	d := resource.Item.(*route53domains.GetDomainDetailOutput)
 	out, err := svc.ListTagsForDomain(ctx, &route53domains.ListTagsForDomainInput{DomainName: d.DomainName}, func(options *route53domains.Options) {
 		// Set region to default global region
 		options.Region = "us-east-1"
@@ -472,10 +465,7 @@ func resolveRoute53DomainTags(ctx context.Context, meta schema.ClientMeta, resou
 
 func resolveRoute53DomainContactExtraParams(extractValue func(*route53domains.GetDomainDetailOutput) *types.ContactDetail) func(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, col schema.Column) error {
 	return func(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, col schema.Column) error {
-		d, ok := resource.Item.(*route53domains.GetDomainDetailOutput)
-		if !ok {
-			return fmt.Errorf("not a *route53domains.GetDomainDetailOutput instance: %T", resource.Item)
-		}
+		d := resource.Item.(*route53domains.GetDomainDetailOutput)
 		detail := extractValue(d)
 		if detail == nil {
 			return nil

--- a/resources/services/route53/health_checks.go
+++ b/resources/services/route53/health_checks.go
@@ -2,7 +2,6 @@ package route53
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -293,10 +292,7 @@ func fetchRoute53HealthChecks(ctx context.Context, meta schema.ClientMeta, paren
 	return nil
 }
 func resolveRoute53healthCheckCloudWatchAlarmConfigurationDimensions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(Route53HealthCheckWrapper)
-	if !ok {
-		return fmt.Errorf("not route53 healch check")
-	}
+	r := resource.Item.(Route53HealthCheckWrapper)
 
 	if r.CloudWatchAlarmConfiguration == nil {
 		return nil

--- a/resources/services/route53/hosted_zones.go
+++ b/resources/services/route53/hosted_zones.go
@@ -408,10 +408,7 @@ func fetchRoute53HostedZones(ctx context.Context, meta schema.ClientMeta, parent
 	return nil
 }
 func fetchRoute53HostedZoneQueryLoggingConfigs(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(Route53HostedZoneWrapper)
-	if !ok {
-		return fmt.Errorf("not route53 hosted zone")
-	}
+	r := parent.Item.(Route53HostedZoneWrapper)
 	svc := meta.(*client.Client).Services().Route53
 	config := route53.ListQueryLoggingConfigsInput{HostedZoneId: r.Id}
 	for {
@@ -428,10 +425,7 @@ func fetchRoute53HostedZoneQueryLoggingConfigs(ctx context.Context, meta schema.
 	return nil
 }
 func fetchRoute53HostedZoneResourceRecordSets(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(Route53HostedZoneWrapper)
-	if !ok {
-		return fmt.Errorf("not route53 hosted zone")
-	}
+	r := parent.Item.(Route53HostedZoneWrapper)
 	svc := meta.(*client.Client).Services().Route53
 	config := route53.ListResourceRecordSetsInput{HostedZoneId: r.Id}
 	for {
@@ -453,10 +447,7 @@ func fetchRoute53HostedZoneResourceRecordSets(ctx context.Context, meta schema.C
 	return nil
 }
 func resolveRoute53hostedZoneResourceRecordSetResourceRecords(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.ResourceRecordSet)
-	if !ok {
-		return fmt.Errorf("not route53 hosted zone")
-	}
+	r := resource.Item.(types.ResourceRecordSet)
 	recordSets := make([]string, 0, len(r.ResourceRecords))
 	for _, t := range r.ResourceRecords {
 		recordSets = append(recordSets, *t.Value)
@@ -464,10 +455,7 @@ func resolveRoute53hostedZoneResourceRecordSetResourceRecords(ctx context.Contex
 	return resource.Set(c.Name, recordSets)
 }
 func fetchRoute53HostedZoneTrafficPolicyInstances(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(Route53HostedZoneWrapper)
-	if !ok {
-		return fmt.Errorf("not route53 hosted zone")
-	}
+	r := parent.Item.(Route53HostedZoneWrapper)
 	config := route53.ListTrafficPolicyInstancesByHostedZoneInput{HostedZoneId: r.Id}
 	svc := meta.(*client.Client).Services().Route53
 	for {
@@ -484,10 +472,7 @@ func fetchRoute53HostedZoneTrafficPolicyInstances(ctx context.Context, meta sche
 	return nil
 }
 func fetchRoute53HostedZoneVpcAssociationAuthorizations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(Route53HostedZoneWrapper)
-	if !ok {
-		return fmt.Errorf("not route53 hosted zone")
-	}
+	r := parent.Item.(Route53HostedZoneWrapper)
 	res <- r.VPCs
 	return nil
 }
@@ -508,31 +493,19 @@ func getRoute53tagsByResourceID(id string, set []types.ResourceTagSet) []types.T
 	return nil
 }
 func resolveRoute53HostedZoneArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	hz, ok := resource.Item.(Route53HostedZoneWrapper)
-	if !ok {
-		return fmt.Errorf("not route53 hosted zone")
-	}
+	hz := resource.Item.(Route53HostedZoneWrapper)
 	return resource.Set(c.Name, client.GenerateResourceARN("route53", "hostedzone", *hz.Id, "", ""))
 }
 func resolveRoute53HostedZoneQueryLoggingConfigsArn(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ql, ok := resource.Item.(types.QueryLoggingConfig)
-	if !ok {
-		return fmt.Errorf("not route53 query logging config")
-	}
+	ql := resource.Item.(types.QueryLoggingConfig)
 	return resource.Set(c.Name, client.GenerateResourceARN("route53", "queryloggingconfig", *ql.Id, "", ""))
 }
 func resolveRoute53HostedZoneTrafficPolicyInstancesArn(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	tp, ok := resource.Item.(types.TrafficPolicyInstance)
-	if !ok {
-		return fmt.Errorf("not route53 traffic policy instance")
-	}
+	tp := resource.Item.(types.TrafficPolicyInstance)
 	return resource.Set(c.Name, client.GenerateResourceARN("route53", "trafficpolicyinstance", *tp.Id, "", ""))
 }
 func resolveRoute53HostedZoneVpcArn(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	cl := meta.(*client.Client)
-	vpc, ok := resource.Item.(types.VPC)
-	if !ok {
-		return fmt.Errorf("not ec2 vpc")
-	}
+	vpc := resource.Item.(types.VPC)
 	return resource.Set(c.Name, client.GenerateResourceARN("ec2", "vpc", *vpc.VPCId, cl.Region, cl.AccountID))
 }

--- a/resources/services/route53/traffic_policies.go
+++ b/resources/services/route53/traffic_policies.go
@@ -3,7 +3,6 @@ package route53
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -139,10 +138,7 @@ func fetchRoute53TrafficPolicies(ctx context.Context, meta schema.ClientMeta, pa
 	return nil
 }
 func fetchRoute53TrafficPolicyVersions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(types.TrafficPolicySummary)
-	if !ok {
-		return fmt.Errorf("not route53 traffic policy")
-	}
+	r := parent.Item.(types.TrafficPolicySummary)
 	config := route53.ListTrafficPolicyVersionsInput{Id: r.Id}
 	svc := meta.(*client.Client).Services().Route53
 	for {
@@ -159,10 +155,7 @@ func fetchRoute53TrafficPolicyVersions(ctx context.Context, meta schema.ClientMe
 	return nil
 }
 func resolveRoute53trafficPolicyVersionDocument(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(types.TrafficPolicy)
-	if !ok {
-		return fmt.Errorf("not route53 traffic policy")
-	}
+	r := resource.Item.(types.TrafficPolicy)
 	var value interface{}
 	err := json.Unmarshal([]byte(*r.Document), &value)
 	if err != nil {

--- a/resources/services/sagemaker/endpoint_configurations.go
+++ b/resources/services/sagemaker/endpoint_configurations.go
@@ -170,10 +170,7 @@ func fetchSagemakerEndpointConfigurations(ctx context.Context, meta schema.Clien
 	return nil
 }
 func fetchSagemakerEndpointConfigurationProductionVariants(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeEndpointConfigOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", r)
-	}
+	r := parent.Item.(*sagemaker.DescribeEndpointConfigOutput)
 	res <- r.ProductionVariants
 	return nil
 }

--- a/resources/services/sagemaker/models.go
+++ b/resources/services/sagemaker/models.go
@@ -245,19 +245,13 @@ func resolveSagemakerModelTags(ctx context.Context, meta schema.ClientMeta, reso
 }
 
 func fetchSagemakerModelContainers(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(WrappedSageMakerModel)
-	if !ok {
-		return fmt.Errorf("expected WrappedModel but got %T", r)
-	}
+	r := parent.Item.(WrappedSageMakerModel)
 	res <- r.Containers
 	return nil
 }
 
 func fetchSagemakerModelVpcConfigs(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(WrappedSageMakerModel)
-	if !ok {
-		return fmt.Errorf("expected WrappedModel but got %T", r)
-	}
+	r := parent.Item.(WrappedSageMakerModel)
 	res <- r.VpcConfig
 	return nil
 }

--- a/resources/services/sagemaker/training_jobs.go
+++ b/resources/services/sagemaker/training_jobs.go
@@ -3,7 +3,6 @@ package sagemaker
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
@@ -600,10 +599,7 @@ func fetchSagemakerTrainingJobs(ctx context.Context, meta schema.ClientMeta, _ *
 }
 
 func fetchSagemakerTrainingJobAlgorithmSpecifications(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.AlgorithmSpecification == nil {
 		return nil
 	}
@@ -611,10 +607,7 @@ func fetchSagemakerTrainingJobAlgorithmSpecifications(_ context.Context, _ schem
 	return nil
 }
 func resolveSagemakerTrainingJobAlgorithmSpecificationsMetricDefinitions(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*types.AlgorithmSpecification)
-	if !ok {
-		return fmt.Errorf("expected AlgorithmSpecification but got %T", resource.Item)
-	}
+	r := resource.Item.(*types.AlgorithmSpecification)
 	if len(r.MetricDefinitions) == 0 {
 		return nil
 	}
@@ -634,10 +627,7 @@ func resolveSagemakerTrainingJobAlgorithmSpecificationsMetricDefinitions(_ conte
 	return resource.Set(c.Name, b)
 }
 func fetchSagemakerTrainingJobDebugHookConfigs(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.DebugHookConfig == nil {
 		return nil
 	}
@@ -646,10 +636,7 @@ func fetchSagemakerTrainingJobDebugHookConfigs(_ context.Context, _ schema.Clien
 	return nil
 }
 func resolveSagemakerTrainingJobDebugHookConfigsCollectionConfigurations(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*types.DebugHookConfig)
-	if !ok {
-		return fmt.Errorf("expected DebugHookConfig but got %T", resource.Item)
-	}
+	r := resource.Item.(*types.DebugHookConfig)
 	if len(r.CollectionConfigurations) == 0 {
 		return nil
 	}
@@ -669,50 +656,32 @@ func resolveSagemakerTrainingJobDebugHookConfigsCollectionConfigurations(_ conte
 	return resource.Set(c.Name, b)
 }
 func fetchSagemakerTrainingJobDebugRuleConfigurations(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	res <- r.DebugRuleConfigurations
 	return nil
 }
 func fetchSagemakerTrainingJobDebugRuleEvaluationStatuses(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	res <- r.DebugRuleEvaluationStatuses
 	return nil
 }
 func fetchSagemakerTrainingJobInputDataConfigs(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	res <- r.InputDataConfig
 	return nil
 }
 func fetchSagemakerTrainingJobProfilerRuleConfigurations(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	res <- r.ProfilerRuleConfigurations
 	return nil
 }
 func fetchSagemakerTrainingJobProfilerRuleEvaluationStatuses(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r, ok := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", parent.Item)
-	}
+	r := parent.Item.(*sagemaker.DescribeTrainingJobOutput)
 	res <- r.ProfilerRuleEvaluationStatuses
 	return nil
 }
 func resolveSagemakerTrainingJobCheckpointConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.CheckpointConfig == nil {
 		return nil
 	}
@@ -724,10 +693,8 @@ func resolveSagemakerTrainingJobCheckpointConfig(_ context.Context, _ schema.Cli
 	return resource.Set(c.Name, checkpointConfig)
 }
 func resolveSagemakerTrainingJobExperimentConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	} else if r.ExperimentConfig == nil {
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
+	if r.ExperimentConfig == nil {
 		return nil
 	}
 
@@ -739,10 +706,7 @@ func resolveSagemakerTrainingJobExperimentConfig(_ context.Context, _ schema.Cli
 	return resource.Set(c.Name, experimentConfig)
 }
 func resolveSagemakerTrainingJobModelArtifacts(__ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.ModelArtifacts == nil {
 		return nil
 	}
@@ -753,10 +717,7 @@ func resolveSagemakerTrainingJobModelArtifacts(__ context.Context, _ schema.Clie
 	return resource.Set(c.Name, modelArtifacts)
 }
 func resolveSagemakerTrainingJobOutputDataConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.OutputDataConfig == nil {
 		return nil
 	}
@@ -768,10 +729,7 @@ func resolveSagemakerTrainingJobOutputDataConfig(_ context.Context, _ schema.Cli
 	return resource.Set(c.Name, outputDataConfig)
 }
 func resolveSagemakerTrainingJobProfilerConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.ProfilerConfig == nil {
 		return nil
 	}
@@ -784,10 +742,7 @@ func resolveSagemakerTrainingJobProfilerConfig(_ context.Context, _ schema.Clien
 	return resource.Set(c.Name, profilerConfig)
 }
 func resolveSagemakerTrainingJobResourceConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.ResourceConfig == nil {
 		return nil
 	}
@@ -801,10 +756,7 @@ func resolveSagemakerTrainingJobResourceConfig(_ context.Context, _ schema.Clien
 	return resource.Set(c.Name, resourceConfig)
 }
 func resolveSagemakerTrainingJobStoppingCondition(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.StoppingCondition == nil {
 		return nil
 	}
@@ -816,10 +768,7 @@ func resolveSagemakerTrainingJobStoppingCondition(_ context.Context, _ schema.Cl
 	return resource.Set(c.Name, stoppingCondition)
 }
 func resolveSagemakerTrainingJobTensorBoardOutputConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.TensorBoardOutputConfig == nil {
 		return nil
 	}
@@ -831,10 +780,7 @@ func resolveSagemakerTrainingJobTensorBoardOutputConfig(_ context.Context, _ sch
 	return resource.Set(c.Name, tensorBoardOutputConfig)
 }
 func resolveSagemakerTrainingJobVpcConfig(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r.VpcConfig == nil {
 		return nil
 	}
@@ -846,10 +792,7 @@ func resolveSagemakerTrainingJobVpcConfig(_ context.Context, _ schema.ClientMeta
 	return resource.Set(c.Name, vpcConfig)
 }
 func resolveSagemakerTrainingJobTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, _ schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeTrainingJobOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if r == nil {
 		return nil
 	}
@@ -874,10 +817,7 @@ func resolveSagemakerTrainingJobTags(ctx context.Context, meta schema.ClientMeta
 	return resource.Set("tags", tags)
 }
 func resolveSagemakerTrainingJobSecondaryStatusTransitions(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if len(r.SecondaryStatusTransitions) == 0 {
 		return nil
 	}
@@ -899,10 +839,7 @@ func resolveSagemakerTrainingJobSecondaryStatusTransitions(_ context.Context, _ 
 	return resource.Set(c.Name, b)
 }
 func resolveSagemakerTrainingJobFinalMetricDataList(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
-	if !ok {
-		return fmt.Errorf("expected DescribeEndpointConfigOutput but got %T", resource.Item)
-	}
+	r := resource.Item.(*sagemaker.DescribeTrainingJobOutput)
 	if len(r.FinalMetricDataList) == 0 {
 		return nil
 	}

--- a/resources/services/secretsmanager/secrets.go
+++ b/resources/services/secretsmanager/secrets.go
@@ -210,10 +210,7 @@ func fetchSecretsmanagerSecretPolicy(ctx context.Context, meta schema.ClientMeta
 }
 
 func resolveSecretsmanagerSecretReplicationStatus(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(WrappedSecret)
-	if !ok {
-		return fmt.Errorf("expected WrappedSecret but got %T", r)
-	}
+	r := resource.Item.(WrappedSecret)
 	var replicationStatus = make([]map[string]interface{}, len(r.ReplicationStatus))
 
 	for i, replication := range r.ReplicationStatus {
@@ -233,10 +230,7 @@ func resolveSecretsmanagerSecretReplicationStatus(_ context.Context, _ schema.Cl
 }
 
 func resolveSecretsmanagerSecretsTags(_ context.Context, _ schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r, ok := resource.Item.(WrappedSecret)
-	if !ok {
-		return fmt.Errorf("expected SecretListEntry but got %T", r)
-	}
+	r := resource.Item.(WrappedSecret)
 	tags := map[string]*string{}
 	for _, t := range r.Tags {
 		tags[*t.Key] = t.Value

--- a/resources/services/sns/topics.go
+++ b/resources/services/sns/topics.go
@@ -2,7 +2,6 @@ package sns
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
@@ -126,10 +125,7 @@ func fetchSnsTopics(ctx context.Context, meta schema.ClientMeta, parent *schema.
 	return nil
 }
 func resolveTopicAttributes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
-	topic, ok := resource.Item.(types.Topic)
-	if !ok {
-		return fmt.Errorf("%T is not topic", resource.Item)
-	}
+	topic := resource.Item.(types.Topic)
 	c := meta.(*client.Client)
 	svc := c.Services().SNS
 	// All topic attributes are returned as a string; we have to handle type conversion

--- a/resources/services/ssm/documents.go
+++ b/resources/services/ssm/documents.go
@@ -3,7 +3,6 @@ package ssm
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -250,10 +249,7 @@ func fetchSsmDocuments(ctx context.Context, meta schema.ClientMeta, parent *sche
 
 func resolveSSMDocumentJSONField(getter func(d *types.DocumentDescription) interface{}) func(context.Context, schema.ClientMeta, *schema.Resource, schema.Column) error {
 	return func(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-		d, ok := resource.Item.(*types.DocumentDescription)
-		if !ok {
-			return fmt.Errorf("not a %T instance: %T", d, resource.Item)
-		}
+		d := resource.Item.(*types.DocumentDescription)
 		b, err := json.Marshal(getter(d))
 		if err != nil {
 			return diag.WrapError(err)
@@ -263,10 +259,7 @@ func resolveSSMDocumentJSONField(getter func(d *types.DocumentDescription) inter
 }
 
 func resolveSSMDocumentTags(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	d, ok := resource.Item.(*types.DocumentDescription)
-	if !ok {
-		return fmt.Errorf("not a %T instance: %T", d, resource.Item)
-	}
+	d := resource.Item.(*types.DocumentDescription)
 	tags := make(map[string]string)
 	for _, t := range d.Tags {
 		tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
@@ -275,10 +268,7 @@ func resolveSSMDocumentTags(_ context.Context, meta schema.ClientMeta, resource 
 }
 
 func ssmDocumentPostResolver(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) (exitErr error) {
-	d, ok := resource.Item.(*types.DocumentDescription)
-	if !ok {
-		return fmt.Errorf("not a %T instance: %T", d, resource.Item)
-	}
+	d := resource.Item.(*types.DocumentDescription)
 	client := meta.(*client.Client)
 	svc := client.Services().SSM
 	optsFn := func(o *ssm.Options) {
@@ -313,10 +303,7 @@ func ssmDocumentPostResolver(ctx context.Context, meta schema.ClientMeta, resour
 }
 
 func resolveSSMDocumentARN(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	d, ok := resource.Item.(*types.DocumentDescription)
-	if !ok {
-		return fmt.Errorf("not a %T instance: %T", d, resource.Item)
-	}
+	d := resource.Item.(*types.DocumentDescription)
 	cl := meta.(*client.Client)
 	return resource.Set(c.Name, client.GenerateResourceARN("ssm", "document", *d.Name, cl.Region, cl.AccountID))
 }

--- a/resources/services/ssm/instances.go
+++ b/resources/services/ssm/instances.go
@@ -2,7 +2,6 @@ package ssm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -248,10 +247,7 @@ func fetchSsmInstances(ctx context.Context, meta schema.ClientMeta, parent *sche
 }
 
 func fetchSsmInstanceComplianceItems(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	instance, ok := parent.Item.(types.InstanceInformation)
-	if !ok {
-		return fmt.Errorf("not a %T instance: %T", instance, parent.Item)
-	}
+	instance := parent.Item.(types.InstanceInformation)
 	client := meta.(*client.Client)
 	svc := client.Services().SSM
 	optsFn := func(o *ssm.Options) {
@@ -275,10 +271,7 @@ func fetchSsmInstanceComplianceItems(ctx context.Context, meta schema.ClientMeta
 }
 
 func resolveSSMInstanceARN(_ context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	instance, ok := resource.Item.(types.InstanceInformation)
-	if !ok {
-		return fmt.Errorf("not a %T instance: %T", instance, resource.Item)
-	}
+	instance := resource.Item.(types.InstanceInformation)
 	cl := meta.(*client.Client)
 	return resource.Set(c.Name, client.GenerateResourceARN("ssm", "managed-instance", *instance.InstanceId, cl.Region, cl.AccountID))
 }

--- a/resources/services/waf/rule_groups.go
+++ b/resources/services/waf/rule_groups.go
@@ -2,7 +2,6 @@ package waf
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/waf"
@@ -97,10 +96,7 @@ func fetchWafRuleGroups(ctx context.Context, meta schema.ClientMeta, parent *sch
 	return nil
 }
 func resolveWafRuleGroupArn(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 	usedClient := meta.(*client.Client)
 
 	// Generate arn
@@ -114,10 +110,7 @@ func resolveWafRuleGroupArn(ctx context.Context, meta schema.ClientMeta, resourc
 	return resource.Set(c.Name, arnStr)
 }
 func resolveWafRuleGroupRuleIds(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 
 	// Resolves rule group rules
 	awsClient := meta.(*client.Client)
@@ -143,10 +136,7 @@ func resolveWafRuleGroupRuleIds(ctx context.Context, meta schema.ClientMeta, res
 	return resource.Set("rule_ids", ruleIDs)
 }
 func resolveWafRuleGroupTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 
 	// Resolve tags for resource
 	usedClient := meta.(*client.Client)

--- a/resources/services/waf/rules.go
+++ b/resources/services/waf/rules.go
@@ -2,7 +2,6 @@ package waf
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/waf"
@@ -123,10 +122,7 @@ func fetchWafRules(ctx context.Context, meta schema.ClientMeta, parent *schema.R
 	return nil
 }
 func resolveWafRuleArn(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(*types.Rule)
-	if !ok {
-		return fmt.Errorf("not a Rule instance: %#v", resource.Item)
-	}
+	rule := resource.Item.(*types.Rule)
 	usedClient := meta.(*client.Client)
 
 	// Generate arn
@@ -140,10 +136,7 @@ func resolveWafRuleArn(ctx context.Context, meta schema.ClientMeta, resource *sc
 	return resource.Set(c.Name, arnStr)
 }
 func resolveWafRuleTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(*types.Rule)
-	if !ok {
-		return fmt.Errorf("not a Rule instance: %#v", resource.Item)
-	}
+	rule := resource.Item.(*types.Rule)
 
 	// Resolve tags for resource
 	usedClient := meta.(*client.Client)
@@ -178,10 +171,7 @@ func resolveWafRuleTags(ctx context.Context, meta schema.ClientMeta, resource *s
 	return resource.Set("tags", outputTags)
 }
 func fetchWafRulePredicates(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	rule, ok := parent.Item.(*types.Rule)
-	if !ok {
-		return fmt.Errorf("not an Rule instance: %#v", rule)
-	}
+	rule := parent.Item.(*types.Rule)
 	res <- rule.Predicates
 	return nil
 }

--- a/resources/services/waf/web_acls.go
+++ b/resources/services/waf/web_acls.go
@@ -3,7 +3,6 @@ package waf
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/waf"
@@ -157,10 +156,7 @@ func fetchWafWebAcls(ctx context.Context, meta schema.ClientMeta, _ *schema.Reso
 	return nil
 }
 func resolveWafWebACLTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	webACL, ok := resource.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WEBACL instance: %#v", resource.Item)
-	}
+	webACL := resource.Item.(*types.WebACL)
 
 	// Resolve tags for resource
 	awsClient := meta.(*client.Client)
@@ -185,18 +181,12 @@ func resolveWafWebACLTags(ctx context.Context, meta schema.ClientMeta, resource 
 	return resource.Set("tags", outputTags)
 }
 func fetchWafWebAclRules(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	webACL, ok := parent.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", parent.Item)
-	}
+	webACL := parent.Item.(*types.WebACL)
 	res <- webACL.Rules
 	return nil
 }
 func resolveWafWebACLRuleExcludedRules(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(types.ActivatedRule)
-	if !ok {
-		return fmt.Errorf("not an ActivatedRule instance")
-	}
+	rule := resource.Item.(types.ActivatedRule)
 	excludedRules := make([]string, len(rule.ExcludedRules))
 	for i := range rule.ExcludedRules {
 		excludedRules[i] = aws.ToString(rule.ExcludedRules[i].RuleId)
@@ -204,10 +194,7 @@ func resolveWafWebACLRuleExcludedRules(ctx context.Context, meta schema.ClientMe
 	return resource.Set(c.Name, excludedRules)
 }
 func resolveWafWebACLRuleLoggingConfiguration(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance")
-	}
+	rule := resource.Item.(*types.WebACL)
 
 	cl := meta.(*client.Client)
 	svc := cl.Services().Waf

--- a/resources/services/wafv2/managed_rule_groups.go
+++ b/resources/services/wafv2/managed_rule_groups.go
@@ -3,7 +3,6 @@ package wafv2
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -109,10 +108,7 @@ func fetchWafv2ManagedRuleGroups(ctx context.Context, meta schema.ClientMeta, pa
 	return nil
 }
 func resolveDescribeManagedRuleGroup(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource) error {
-	managedRuleGroupSum, ok := resource.Item.(types.ManagedRuleGroupSummary)
-	if !ok {
-		return fmt.Errorf("not a ManagedRuleGroupSummary instance: %#v", resource.Item)
-	}
+	managedRuleGroupSum := resource.Item.(types.ManagedRuleGroupSummary)
 
 	c := meta.(*client.Client)
 	service := c.Services().WafV2

--- a/resources/services/wafv2/rule_groups.go
+++ b/resources/services/wafv2/rule_groups.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -170,10 +169,7 @@ func fetchWafv2RuleGroups(ctx context.Context, meta schema.ClientMeta, parent *s
 	return nil
 }
 func resolveWafv2ruleGroupTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 
 	client := meta.(*client.Client)
 	service := client.Services().WafV2
@@ -199,10 +195,7 @@ func resolveWafv2ruleGroupTags(ctx context.Context, meta schema.ClientMeta, reso
 	return resource.Set(c.Name, outputTags)
 }
 func resolveWafv2ruleGroupPolicy(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 
 	cl := meta.(*client.Client)
 	service := cl.Services().WafV2
@@ -223,10 +216,7 @@ func resolveWafv2ruleGroupPolicy(ctx context.Context, meta schema.ClientMeta, re
 	return resource.Set(c.Name, policy.Policy)
 }
 func resolveWafv2ruleGroupRules(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 	if len(ruleGroup.Rules) == 0 {
 		return nil
 	}
@@ -237,10 +227,7 @@ func resolveWafv2ruleGroupRules(ctx context.Context, meta schema.ClientMeta, res
 	return resource.Set(c.Name, data)
 }
 func resolveWafv2AvailableLabels(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 	labels := make([]string, len(ruleGroup.AvailableLabels))
 	for i, l := range ruleGroup.AvailableLabels {
 		labels[i] = *l.Name
@@ -248,10 +235,7 @@ func resolveWafv2AvailableLabels(ctx context.Context, meta schema.ClientMeta, re
 	return resource.Set(c.Name, labels)
 }
 func resolveWafv2ConsumedLabels(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	ruleGroup, ok := resource.Item.(*types.RuleGroup)
-	if !ok {
-		return fmt.Errorf("not a RuleGroup instance: %#v", resource.Item)
-	}
+	ruleGroup := resource.Item.(*types.RuleGroup)
 	labels := make([]string, len(ruleGroup.ConsumedLabels))
 	for i, l := range ruleGroup.ConsumedLabels {
 		labels[i] = *l.Name

--- a/resources/services/wafv2/web_acls.go
+++ b/resources/services/wafv2/web_acls.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -343,10 +342,7 @@ func fetchWafv2WebAcls(ctx context.Context, meta schema.ClientMeta, parent *sche
 	return nil
 }
 func resolveWafv2webACLResourcesForWebACL(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	webACL, ok := resource.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", resource.Item)
-	}
+	webACL := resource.Item.(*types.WebACL)
 
 	client := meta.(*client.Client)
 	service := client.Services().WafV2
@@ -361,10 +357,7 @@ func resolveWafv2webACLResourcesForWebACL(ctx context.Context, meta schema.Clien
 	return resource.Set(c.Name, resourceArns.ResourceArns)
 }
 func resolveWafv2webACLTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	webACL, ok := resource.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", resource.Item)
-	}
+	webACL := resource.Item.(*types.WebACL)
 
 	client := meta.(*client.Client)
 	service := client.Services().WafV2
@@ -390,10 +383,7 @@ func resolveWafv2webACLTags(ctx context.Context, meta schema.ClientMeta, resourc
 	return resource.Set(c.Name, outputTags)
 }
 func resolveWafv2webACLDefaultAction(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	webACL, ok := resource.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", resource.Item)
-	}
+	webACL := resource.Item.(*types.WebACL)
 	if webACL.DefaultAction == nil {
 		return nil
 	}
@@ -404,18 +394,12 @@ func resolveWafv2webACLDefaultAction(ctx context.Context, meta schema.ClientMeta
 	return resource.Set(c.Name, data)
 }
 func fetchWafv2WebAclRules(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	webACL, ok := parent.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", parent.Item)
-	}
+	webACL := parent.Item.(*types.WebACL)
 	res <- webACL.Rules
 	return nil
 }
 func resolveWafv2webACLRuleStatement(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(types.Rule)
-	if !ok {
-		return fmt.Errorf("not an Rule instance: %#v", resource.Item)
-	}
+	rule := resource.Item.(types.Rule)
 	if rule.Statement == nil {
 		return nil
 	}
@@ -426,10 +410,7 @@ func resolveWafv2webACLRuleStatement(ctx context.Context, meta schema.ClientMeta
 	return resource.Set(c.Name, data)
 }
 func resolveWafv2webACLRuleAction(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(types.Rule)
-	if !ok {
-		return fmt.Errorf("not an Rule instance: %#v", resource.Item)
-	}
+	rule := resource.Item.(types.Rule)
 	if rule.Action == nil {
 		return nil
 	}
@@ -440,10 +421,7 @@ func resolveWafv2webACLRuleAction(ctx context.Context, meta schema.ClientMeta, r
 	return resource.Set(c.Name, data)
 }
 func resolveWafv2webACLRuleOverrideAction(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(types.Rule)
-	if !ok {
-		return fmt.Errorf("not an Rule instance: %#v", resource.Item)
-	}
+	rule := resource.Item.(types.Rule)
 	if rule.OverrideAction == nil {
 		return nil
 	}
@@ -454,10 +432,7 @@ func resolveWafv2webACLRuleOverrideAction(ctx context.Context, meta schema.Clien
 	return resource.Set(c.Name, data)
 }
 func resolveWafv2webACLRuleLabels(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(types.Rule)
-	if !ok {
-		return fmt.Errorf("not an Rule instance: %#v", resource.Item)
-	}
+	rule := resource.Item.(types.Rule)
 	labels := make([]string, len(rule.RuleLabels))
 	for i := range rule.RuleLabels {
 		labels[i] = aws.ToString(rule.RuleLabels[i].Name)
@@ -465,18 +440,12 @@ func resolveWafv2webACLRuleLabels(ctx context.Context, meta schema.ClientMeta, r
 	return resource.Set(c.Name, labels)
 }
 func fetchWafv2WebAclPostProcessFirewallManagerRuleGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	webACL, ok := parent.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", parent.Item)
-	}
+	webACL := parent.Item.(*types.WebACL)
 	res <- webACL.PostProcessFirewallManagerRuleGroups
 	return nil
 }
 func resolveWafv2webACLPostProcessFirewallManagerRuleGroupStatement(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	firewallManagerRuleGroup, ok := resource.Item.(types.FirewallManagerRuleGroup)
-	if !ok {
-		return fmt.Errorf("not an FirewallManagerRuleGroup instance: %#v", resource.Item)
-	}
+	firewallManagerRuleGroup := resource.Item.(types.FirewallManagerRuleGroup)
 	if firewallManagerRuleGroup.FirewallManagerStatement == nil {
 		return nil
 	}
@@ -487,10 +456,7 @@ func resolveWafv2webACLPostProcessFirewallManagerRuleGroupStatement(ctx context.
 	return resource.Set(c.Name, data)
 }
 func resolveWafv2webACLPostProcessFirewallManagerRuleGroupOverrideAction(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	firewallManagerRuleGroup, ok := resource.Item.(types.FirewallManagerRuleGroup)
-	if !ok {
-		return fmt.Errorf("not an FirewallManagerRuleGroup instance: %#v", resource.Item)
-	}
+	firewallManagerRuleGroup := resource.Item.(types.FirewallManagerRuleGroup)
 	if firewallManagerRuleGroup.OverrideAction == nil {
 		return nil
 	}
@@ -501,18 +467,12 @@ func resolveWafv2webACLPostProcessFirewallManagerRuleGroupOverrideAction(ctx con
 	return resource.Set(c.Name, data)
 }
 func fetchWafv2WebAclPreProcessFirewallManagerRuleGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	webACL, ok := parent.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance: %#v", parent.Item)
-	}
+	webACL := parent.Item.(*types.WebACL)
 	res <- webACL.PreProcessFirewallManagerRuleGroups
 	return nil
 }
 func resolveWafv2webACLPreProcessFirewallManagerRuleGroupStatement(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	firewallManagerRuleGroup, ok := resource.Item.(types.FirewallManagerRuleGroup)
-	if !ok {
-		return fmt.Errorf("not an FirewallManagerRuleGroup instance: %#v", resource.Item)
-	}
+	firewallManagerRuleGroup := resource.Item.(types.FirewallManagerRuleGroup)
 	if firewallManagerRuleGroup.FirewallManagerStatement == nil {
 		return nil
 	}
@@ -523,10 +483,7 @@ func resolveWafv2webACLPreProcessFirewallManagerRuleGroupStatement(ctx context.C
 	return resource.Set(c.Name, data)
 }
 func resolveWafv2webACLPreProcessFirewallManagerRuleGroupOverrideAction(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	firewallManagerRuleGroup, ok := resource.Item.(types.FirewallManagerRuleGroup)
-	if !ok {
-		return fmt.Errorf("not an FirewallManagerRuleGroup instance: %#v", resource.Item)
-	}
+	firewallManagerRuleGroup := resource.Item.(types.FirewallManagerRuleGroup)
 	if firewallManagerRuleGroup.OverrideAction == nil {
 		return nil
 	}
@@ -537,10 +494,7 @@ func resolveWafv2webACLPreProcessFirewallManagerRuleGroupOverrideAction(ctx cont
 	return resource.Set(c.Name, data)
 }
 func resolveWafV2WebACLRuleLoggingConfiguration(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	rule, ok := resource.Item.(*types.WebACL)
-	if !ok {
-		return fmt.Errorf("not an WebACL instance")
-	}
+	rule := resource.Item.(*types.WebACL)
 	cl := meta.(*client.Client)
 	svc := cl.Services().WafV2
 	cfg := wafv2.GetLoggingConfigurationInput{


### PR DESCRIPTION
There is no need for type assertion in resolvers for the following reasons:
* They should be caught in unit-tests
* Even if they happen we catch panics and they are more useful with line numbers
* If we do use type assertion checks we will need to add diag.WrapError
* Moreover this actually hide crucial information like what was the type? as this is crucial to debug and understand what happens.

This removes a lot of unnecessary boilerplate-code which also gives bad example
for future contributions.

p.s - this was done with regex in vscode :) 

```
Search:
([a-zA-Z_]*), ok := (.*)\n[ \t]*if !ok \{\n.*\n[ \t]*\}
Replace:
$1 := $2
```