### PR TITLE
feat: Reduce ECS API Calls

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,6 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.32.1 h1:vSq2JEkmyk2IF5XKc9+nmnm1/ou0
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.32.1/go.mod h1:4j+WaEPuilaaff4hE2yZ+HRlWL9dTJW+cO9iuCnn1NI=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.2.0 h1:6ExOoVgntAVuVARounLgbXnMLWjy0l5iXf/wAu90NgI=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.2.0/go.mod h1:fxAA3GE+slgrsFyA3bsN0lknZ+egpPdvu7GosNGoVT4=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.2.0 h1:LlnxkpvIugxKNMjANn4KsD4/Vxs2yc7KHqtmGCwY+5w=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.2.0/go.mod h1:t2Lhvr7z1eoNmVILjyAdhL8iElYeLeGSEK559gzbAVk=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.1 h1:MZKnNbcKEoHIhGEcsybTjc7yNsKlZr5Fyu3XjVS1/ug=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.18.1/go.mod h1:IMFY+VG/R/8MXaShcrlq7M8gfySqc7IIQTUWxJEw/FQ=
 github.com/aws/aws-sdk-go-v2/service/efs v1.2.0 h1:PCLM4aShavpVcyXqUoUsQpMJ+Z/PLOFjQuV3NKxitmg=

--- a/resources/services/ecs/task_definitions.go
+++ b/resources/services/ecs/task_definitions.go
@@ -594,7 +594,7 @@ type TaskDefinitionWrapper struct {
 	Tags []types.Tag
 }
 
-func fetchEcsTaskDefinitions(ctx context.Context, res chan<- interface{}, svc client.EcsClient, region, taskArn string) error {
+func fetchEcsTaskDefinition(ctx context.Context, res chan<- interface{}, svc client.EcsClient, region, taskArn string) error {
 	describeClusterOutput, err := svc.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskArn),
 		Include:        []types.TaskDefinitionField{types.TaskDefinitionFieldTags},
@@ -635,7 +635,7 @@ func listEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent 
 		}
 
 		for _, t := range listClustersOutput.TaskDefinitionArns {
-			err := fetchEcsTaskDefinitions(ctx, res, svc, region, t)
+			err := fetchEcsTaskDefinition(ctx, res, svc, region, t)
 			if err != nil {
 				return err
 			}

--- a/resources/services/ecs/task_definitions.go
+++ b/resources/services/ecs/task_definitions.go
@@ -649,7 +649,7 @@ func listEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent 
 	return nil
 }
 func resolveEcsTaskDefinitionsInferenceAccelerators(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r := resource.Item.(types.TaskDefinition)
+	r := resource.Item.(TaskDefinitionWrapper)
 	j := map[string]interface{}{}
 	for _, a := range r.InferenceAccelerators {
 		j[*a.DeviceName] = *a.DeviceType
@@ -657,7 +657,7 @@ func resolveEcsTaskDefinitionsInferenceAccelerators(ctx context.Context, meta sc
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionsPlacementConstraints(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r := resource.Item.(types.TaskDefinition)
+	r := resource.Item.(TaskDefinitionWrapper)
 	j := map[string]interface{}{}
 	for _, p := range r.PlacementConstraints {
 		j[*p.Expression] = p.Type
@@ -665,7 +665,7 @@ func resolveEcsTaskDefinitionsPlacementConstraints(ctx context.Context, meta sch
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionsProxyConfigurationProperties(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r := resource.Item.(types.TaskDefinition)
+	r := resource.Item.(TaskDefinitionWrapper)
 	j := map[string]interface{}{}
 	if r.ProxyConfiguration == nil {
 		return nil
@@ -676,7 +676,7 @@ func resolveEcsTaskDefinitionsProxyConfigurationProperties(ctx context.Context, 
 	return resource.Set(c.Name, j)
 }
 func resolveEcsTaskDefinitionsRequiresAttributes(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
-	r := resource.Item.(types.TaskDefinition)
+	r := resource.Item.(TaskDefinitionWrapper)
 	data, err := json.Marshal(r.RequiresAttributes)
 	if err != nil {
 		return diag.WrapError(err)
@@ -684,7 +684,7 @@ func resolveEcsTaskDefinitionsRequiresAttributes(ctx context.Context, meta schem
 	return resource.Set(c.Name, data)
 }
 func fetchEcsTaskDefinitionContainerDefinitions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r := parent.Item.(types.TaskDefinition)
+	r := parent.Item.(TaskDefinitionWrapper)
 	res <- r.ContainerDefinitions
 	return nil
 }
@@ -826,7 +826,7 @@ func resolveEcsTaskDefinitionContainerDefinitionsVolumesFrom(ctx context.Context
 	return resource.Set(c.Name, j)
 }
 func fetchEcsTaskDefinitionVolumes(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	r := parent.Item.(types.TaskDefinition)
+	r := parent.Item.(TaskDefinitionWrapper)
 	res <- r.Volumes
 	return nil
 }

--- a/resources/services/ecs/task_definitions.go
+++ b/resources/services/ecs/task_definitions.go
@@ -595,7 +595,7 @@ type TaskDefinitionWrapper struct {
 }
 
 func fetchEcsTaskDefinition(ctx context.Context, res chan<- interface{}, svc client.EcsClient, region, taskArn string) error {
-	describeClusterOutput, err := svc.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
+	describeTaskDefinitionOutput, err := svc.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskArn),
 		Include:        []types.TaskDefinitionField{types.TaskDefinitionFieldTags},
 	}, func(o *ecs.Options) {
@@ -604,12 +604,12 @@ func fetchEcsTaskDefinition(ctx context.Context, res chan<- interface{}, svc cli
 	if err != nil {
 		return diag.WrapError(err)
 	}
-	if describeClusterOutput.TaskDefinition == nil {
+	if describeTaskDefinitionOutput.TaskDefinition == nil {
 		return nil
 	}
 	res <- TaskDefinitionWrapper{
-		TaskDefinition: describeClusterOutput.TaskDefinition,
-		Tags:           describeClusterOutput.Tags,
+		TaskDefinition: describeTaskDefinitionOutput.TaskDefinition,
+		Tags:           describeTaskDefinitionOutput.Tags,
 	}
 	return nil
 }

--- a/resources/services/ecs/task_definitions.go
+++ b/resources/services/ecs/task_definitions.go
@@ -588,12 +588,15 @@ func EcsTaskDefinitions() *schema.Table {
 	}
 }
 
+// func fetchEcsTaskDefinitions(ctx)
+
 // ====================================================================================================================
 //                                               Table Resolver Functions
 // ====================================================================================================================
 
-func fetchEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
+func listEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	var config ecs.ListTaskDefinitionsInput
+
 	region := meta.(*client.Client).Region
 	svc := meta.(*client.Client).Services().ECS
 	for {
@@ -607,7 +610,10 @@ func fetchEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent
 			return nil
 		}
 		for _, t := range listClustersOutput.TaskDefinitionArns {
-			describeClusterOutput, err := svc.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{TaskDefinition: &t}, func(o *ecs.Options) {
+			describeClusterOutput, err := svc.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
+				TaskDefinition: &t,
+				Include:        []types.TaskDefinitionField{types.TaskDefinitionFieldTags},
+			}, func(o *ecs.Options) {
 				o.Region = region
 			})
 			if err != nil {

--- a/resources/services/ecs/task_definitions.go
+++ b/resources/services/ecs/task_definitions.go
@@ -588,13 +588,11 @@ func EcsTaskDefinitions() *schema.Table {
 	}
 }
 
-// func fetchEcsTaskDefinitions(ctx)
-
 // ====================================================================================================================
 //                                               Table Resolver Functions
 // ====================================================================================================================
 
-func listEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
+func fetchEcsTaskDefinitions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	var config ecs.ListTaskDefinitionsInput
 
 	region := meta.(*client.Client).Region

--- a/resources/services/ecs/task_definitions_mock_test.go
+++ b/resources/services/ecs/task_definitions_mock_test.go
@@ -29,13 +29,6 @@ func buildEcsTaskDefinitions(t *testing.T, ctrl *gomock.Controller) client.Servi
 	}
 	m.EXPECT().DescribeTaskDefinition(gomock.Any(), gomock.Any(), gomock.Any()).Return(taskDefinition, nil)
 
-	tags := &ecs.ListTagsForResourceOutput{}
-	err = faker.FakeData(&tags)
-	if err != nil {
-		t.Fatal(err)
-	}
-	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(tags, nil)
-
 	return client.Services{
 		ECS: m,
 	}


### PR DESCRIPTION
This reduces the number of calls by 50% as tags don't need to be grabbed again.

More work can be done to parallelize the `fetchEcsTaskDefinition`  