### PR TITLE
fix: Past migrations: aws_ec2_security_group_ip_permission_user_id_group_pairs PK

### DIFF
--- a/resources/provider/migrations/postgres/15_v0.10.0.up.sql
+++ b/resources/provider/migrations/postgres/15_v0.10.0.up.sql
@@ -2605,7 +2605,7 @@ CREATE TABLE IF NOT EXISTS "aws_ec2_security_group_ip_permission_user_id_group_p
 	"user_id" text,
 	"vpc_id" text,
 	"vpc_peering_connection_id" text,
-	CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY(security_group_ip_permission_cq_id,group_id,user_id),
+	CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY(cq_id),
 	UNIQUE(cq_id),
 	FOREIGN KEY (security_group_ip_permission_cq_id) REFERENCES aws_ec2_security_group_ip_permissions(cq_id) ON DELETE CASCADE
 );

--- a/resources/provider/migrations/postgres/23_v0.10.15.down.sql
+++ b/resources/provider/migrations/postgres/23_v0.10.15.down.sql
@@ -5,7 +5,7 @@ ALTER TABLE IF EXISTS "aws_ec2_images" DROP COLUMN IF EXISTS "last_launched_time
 
 -- Resource: ec2.security_groups
 ALTER TABLE IF EXISTS aws_ec2_security_group_ip_permission_user_id_group_pairs DROP CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk;
-ALTER TABLE IF EXISTS aws_ec2_security_group_ip_permission_user_id_group_pairs ADD CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY (security_group_ip_permission_cq_id,group_id,user_id);
+ALTER TABLE IF EXISTS aws_ec2_security_group_ip_permission_user_id_group_pairs ADD CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY (cq_id);
 
 -- Resource: workspaces.directories
 DROP TABLE IF EXISTS aws_workspaces_directories;

--- a/resources/provider/migrations/timescale/15_v0.10.0.up.sql
+++ b/resources/provider/migrations/timescale/15_v0.10.0.up.sql
@@ -2858,7 +2858,7 @@ CREATE TABLE IF NOT EXISTS "aws_ec2_security_group_ip_permission_user_id_group_p
 	"user_id" text,
 	"vpc_id" text,
 	"vpc_peering_connection_id" text,
-	CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY(cq_fetch_date,security_group_ip_permission_cq_id,group_id,user_id),
+	CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY(cq_fetch_date,cq_id),
 	UNIQUE(cq_fetch_date,cq_id)
 );
 CREATE INDEX ON aws_ec2_security_group_ip_permission_user_id_group_pairs (cq_fetch_date, security_group_ip_permission_cq_id);

--- a/resources/provider/migrations/timescale/23_v0.10.15.down.sql
+++ b/resources/provider/migrations/timescale/23_v0.10.15.down.sql
@@ -5,7 +5,7 @@ ALTER TABLE IF EXISTS "aws_ec2_images" DROP COLUMN IF EXISTS "last_launched_time
 
 -- Resource: ec2.security_groups
 ALTER TABLE IF EXISTS aws_ec2_security_group_ip_permission_user_id_group_pairs DROP CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk;
-ALTER TABLE IF EXISTS aws_ec2_security_group_ip_permission_user_id_group_pairs ADD CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY (cq_fetch_date,security_group_ip_permission_cq_id,group_id,user_id);
+ALTER TABLE IF EXISTS aws_ec2_security_group_ip_permission_user_id_group_pairs ADD CONSTRAINT aws_ec2_security_group_ip_permission_user_id_group_pairs_pk PRIMARY KEY (cq_fetch_date,cq_id);
 
 -- Resource: workspaces.directories
 DROP TABLE IF EXISTS aws_workspaces_directories;


### PR DESCRIPTION
This should enable up/down migrations without failing. May be related to #496.