### PR TITLE
fix: Shared Images Cannot Access LastLaunched

### DIFF
--- a/resources/services/ec2/images.go
+++ b/resources/services/ec2/images.go
@@ -325,6 +325,9 @@ func resolveEc2ImageLastLaunchedTime(ctx context.Context, meta schema.ClientMeta
 	cl := meta.(*client.Client)
 	image := resource.Item.(types.Image)
 	svc := cl.Services().EC2
+	if *image.OwnerId != cl.AccountID {
+		return nil
+	}
 	opts := ec2.DescribeImageAttributeInput{
 		Attribute: types.ImageAttributeNameLastLaunchedTime,
 		ImageId:   image.ImageId,

--- a/resources/services/ec2/images_mock_test.go
+++ b/resources/services/ec2/images_mock_test.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloudquery/cq-provider-aws/client"
@@ -21,6 +22,8 @@ func buildEc2ImagesMock(t *testing.T, ctrl *gomock.Controller) client.Services {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	g.OwnerId = aws.String("testAccount")
 
 	m.EXPECT().DescribeImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&ec2.DescribeImagesOutput{


### PR DESCRIPTION
Now that we are grabbing all AMIs that are shared with an account, we cannot grab the `LastLaunched` data as that is only available from the owner account