### PR TITLE
chore(make-file): Fix `pg-stop` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ pg-start:
 	docker run -p 5432:5432 -e POSTGRES_PASSWORD=pass -d postgres
 
 # stop a running docker container
-.PHONY: pg-start
-pg-start:
+.PHONY: pg-stop
+pg-stop:
 	docker stop $$(docker ps -q --filter ancestor=postgres:latest)
 
 # connect to pg via cli


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/cloudquery/cq-provider-aws/pull/763