### PR TITLE
chore(makefile): Better db migration prefix suggestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-integration:
 # Create a DB migration
 .PHONY: db-migration
 db-migration:
-    # Get latest migration file, trim extention, increment path and then order
+    # Get latest migration file, trim extention, increment patch and then order
 	$(eval prefixSuggestion:=$(shell ls -1 resources/provider/migrations/postgres/ | tail -1 | awk '{print substr($$0, 1, length($$0)-7)}' | awk -F. -v OFS=. '{$$NF += 1 ; print}' | awk -F_ -v OFS=_ '{$$1 += 1 ; print}'))
 	@if [[ "$(prefix)" == "" ]]; then echo "Invalid prefix, see example 'make db-migration prefix=$(prefixSuggestion)'" && exit 1; fi;
 	go run tools/migrations/main.go -prefix "${prefix}" -dsn 'postgres://postgres:pass@localhost:5432/postgres?sslmode=disable'

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ test-integration:
 # Create a DB migration
 .PHONY: db-migration
 db-migration:
-	@if [[ "$(prefix)" == "" ]]; then echo "Invalid prefix, see example 'make db-migration prefix=26_v0.10.18'" && exit 1; fi;
+    # Get latest migration file, trim extention, increment path and then order
+	$(eval prefixSuggestion:=$(shell ls -1 resources/provider/migrations/postgres/ | tail -1 | awk '{print substr($$0, 1, length($$0)-7)}' | awk -F. -v OFS=. '{$$NF += 1 ; print}' | awk -F_ -v OFS=_ '{$$1 += 1 ; print}'))
+	@if [[ "$(prefix)" == "" ]]; then echo "Invalid prefix, see example 'make db-migration prefix=$(prefixSuggestion)'" && exit 1; fi;
 	go run tools/migrations/main.go -prefix "${prefix}" -dsn 'postgres://postgres:pass@localhost:5432/postgres?sslmode=disable'
 	go run tools/migrations/main.go -prefix "${prefix}" -fake-tsdb -dsn 'postgres://postgres:pass@localhost:5432/postgres?sslmode=disable'


### PR DESCRIPTION
Extracted from https://github.com/cloudquery/cq-provider-aws/pull/751#discussion_r857644843.

In https://github.com/cloudquery/cq-provider-aws/pull/751#discussion_r857644843 we discussed using the GitHub CLI to get the latest release or `git tag`, so we can suggest the prefix.

With this PR I'm using the existing migration files to suggest a prefix.