### PR TITLE
feat: Add tags to sns fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ crash.log
 cloudquery
 cloudquery.db
 cloudquery.zip
+# goenv
+.go-version
 /config.yml
 dist/
 vendor/

--- a/client/mocks/mock_sns.go
+++ b/client/mocks/mock_sns.go
@@ -75,6 +75,26 @@ func (mr *MockSnsClientMockRecorder) ListSubscriptions(arg0, arg1 interface{}, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockSnsClient)(nil).ListSubscriptions), varargs...)
 }
 
+// ListTagsForResource mocks base method.
+func (m *MockSnsClient) ListTagsForResource(arg0 context.Context, arg1 *sns.ListTagsForResourceInput, arg2 ...func(*sns.Options)) (*sns.ListTagsForResourceOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListTagsForResource", varargs...)
+	ret0, _ := ret[0].(*sns.ListTagsForResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTagsForResource indicates an expected call of ListTagsForResource.
+func (mr *MockSnsClientMockRecorder) ListTagsForResource(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockSnsClient)(nil).ListTagsForResource), varargs...)
+}
+
 // ListTopics mocks base method.
 func (m *MockSnsClient) ListTopics(arg0 context.Context, arg1 *sns.ListTopicsInput, arg2 ...func(*sns.Options)) (*sns.ListTopicsOutput, error) {
 	m.ctrl.T.Helper()

--- a/client/services.go
+++ b/client/services.go
@@ -407,6 +407,7 @@ type SnsClient interface {
 	ListTopics(ctx context.Context, params *sns.ListTopicsInput, optFns ...func(*sns.Options)) (*sns.ListTopicsOutput, error)
 	ListSubscriptions(ctx context.Context, params *sns.ListSubscriptionsInput, optFns ...func(*sns.Options)) (*sns.ListSubscriptionsOutput, error)
 	GetTopicAttributes(ctx context.Context, params *sns.GetTopicAttributesInput, optFns ...func(*sns.Options)) (*sns.GetTopicAttributesOutput, error)
+	ListTagsForResource(ctx context.Context, params *sns.ListTagsForResourceInput, optFns ...func(*sns.Options)) (*sns.ListTagsForResourceOutput, error)
 }
 
 //go:generate mockgen -package=mocks -destination=./mocks/mock_ecs.go . EcsClient

--- a/docs/tables/aws_sns_topics.md
+++ b/docs/tables/aws_sns_topics.md
@@ -18,3 +18,4 @@ AWS SNS topic
 |content_based_deduplication|boolean|Enables content-based deduplication for FIFO topics.|
 |kms_master_key_id|text|The ID of an AWS managed customer master key (CMK) for Amazon SNS or a custom CMK|
 |arn|text|The topic's ARN.|
+|tags|jsonb|Topic tags.|

--- a/resources/provider/migrations/postgres/28_v0.11.2.down.sql
+++ b/resources/provider/migrations/postgres/28_v0.11.2.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS "aws_sns_topics" DROP COLUMN IF EXISTS "tags";

--- a/resources/provider/migrations/postgres/28_v0.11.2.up.sql
+++ b/resources/provider/migrations/postgres/28_v0.11.2.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS "aws_sns_topics" ADD COLUMN IF NOT EXISTS "tags" jsonb;

--- a/resources/provider/migrations/timescale/28_v0.11.2.down.sql
+++ b/resources/provider/migrations/timescale/28_v0.11.2.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS "aws_sns_topics" DROP COLUMN IF EXISTS "tags";

--- a/resources/provider/migrations/timescale/28_v0.11.2.up.sql
+++ b/resources/provider/migrations/timescale/28_v0.11.2.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS "aws_sns_topics" ADD COLUMN IF NOT EXISTS "tags" jsonb;

--- a/resources/services/sns/topics.go
+++ b/resources/services/sns/topics.go
@@ -144,11 +144,6 @@ func resolveTopicAttributes(ctx context.Context, meta schema.ClientMeta, resourc
 	if err != nil {
 		return diag.WrapError(err)
 	}
-
-	if err != nil {
-		return diag.WrapError(err)
-	}
-
 	// Set all attributes
 	if err := resource.Set("subscriptions_confirmed", cast.ToInt(output.Attributes["SubscriptionsConfirmed"])); err != nil {
 		return err

--- a/resources/services/sns/topics.go
+++ b/resources/services/sns/topics.go
@@ -155,7 +155,6 @@ func resolveTopicAttributes(ctx context.Context, meta schema.ClientMeta, resourc
 	if err != nil {
 		return diag.WrapError(err)
 	}
-	fmt.Println(tags)
 
 	// Set all attributes
 	if err := resource.Set("subscriptions_confirmed", cast.ToInt(output.Attributes["SubscriptionsConfirmed"])); err != nil {

--- a/resources/services/sns/topics.go
+++ b/resources/services/sns/topics.go
@@ -100,7 +100,7 @@ func SnsTopics() *schema.Table {
 			},
 			{
 				Name:          "tags",
-				Description:   "Queue tags.",
+				Description:   "Topic tags.",
 				Type:          schema.TypeJSON,
 				IgnoreInTests: true,
 			},

--- a/resources/services/sns/topics_mock_test.go
+++ b/resources/services/sns/topics_mock_test.go
@@ -14,9 +14,14 @@ import (
 func buildSnsTopics(t *testing.T, ctrl *gomock.Controller) client.Services {
 	m := mocks.NewMockSnsClient(ctrl)
 	topic := types.Topic{}
+	tag := types.Tag{}
 	err := faker.FakeData(&topic)
 	if err != nil {
 		t.Fatal(err)
+	}
+	tagerr := faker.FakeData(&tag)
+	if tagerr != nil {
+		t.Fatal(tagerr)
 	}
 
 	m.EXPECT().ListTopics(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -38,6 +43,10 @@ func buildSnsTopics(t *testing.T, ctrl *gomock.Controller) client.Services {
 				"DeliveryPolicy":            `{"stuff": 3}`,
 				"EffectiveDeliveryPolicy":   `{"stuff": 3}`,
 			},
+		}, nil)
+	m.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&sns.ListTagsForResourceOutput{
+			Tags: []types.Tag{tag},
 		}, nil)
 	return client.Services{
 		SNS: m,

--- a/terraform/sns/modules/test/sns.tf
+++ b/terraform/sns/modules/test/sns.tf
@@ -9,4 +9,8 @@ module "sns" {
   name_prefix       = "${var.prefix}-sns-cq-provider"
   display_name      = "${var.prefix}-sns-cq-provider"
   kms_master_key_id = aws_kms_key.sns_kms_key.id
+  tags = {
+    tag1 = "foo"
+    tag2 = "bar"
+  }
 }


### PR DESCRIPTION
https://github.com/cloudquery/cq-provider-aws/issues/803
This adds an extra api call to retrieve the tags of each SNS topic.