### PR TITLE
fix: Fix panic on fetching wafv2 without us-east-1

### DIFF
--- a/client/multiplexers.go
+++ b/client/multiplexers.go
@@ -60,7 +60,7 @@ func ServiceAccountRegionScopeMultiplexer(service string) func(meta schema.Clien
 		client := meta.(*Client)
 		for accountID := range client.ServicesManager.services {
 			// always fetch cloudfront related resources
-			l = append(l, client.withAccountIDRegionAndScope(accountID, "us-east-1", wafv2types.ScopeCloudfront))
+			l = append(l, client.withAccountIDRegionAndScope(accountID, cloudfrontScopeRegion, wafv2types.ScopeCloudfront))
 			for region := range client.ServicesManager.services[accountID] {
 				if !isSupportedServiceForRegion(service, region) {
 					meta.Logger().Trace("region is not supported for service", "service", service, "region", region)


### PR DESCRIPTION
The bug happens when:

* user has a list of regions that doesn't include us-east-1
* wafv2 resources are fetched

The issue is that multiplexer always produces a client that has us-east-1 as a region and cloudfront scope.
When fetching starts, (*Client).Services call is made, which returns nil because there is no client for us-east-1 region.
This fix changes multiplexer to fetch cloudfront resources only when there is us-east-1 region.

Closes #828 