### PR TITLE
fix(ec2): Handle snapshot not found error

### DIFF
--- a/resources/services/ec2/ebs_snapshots.go
+++ b/resources/services/ec2/ebs_snapshots.go
@@ -169,7 +169,7 @@ func resolveEc2ebsSnapshotCreateVolumePermissions(ctx context.Context, meta sche
 
 	if err != nil {
 		if isSnapshotNotFoundError(err) {
-			meta.Logger().Debug("Failed extracting snapshot volume permissions. Snapshot not found", "SnapshotId", r.SnapshotId)
+			meta.Logger().Debug("Failed extracting snapshot volume permissions", "SnapshotId", r.SnapshotId, "error", err)
 			return nil
 		}
 		return diag.WrapError(err)

--- a/resources/services/ec2/ebs_snapshots.go
+++ b/resources/services/ec2/ebs_snapshots.go
@@ -3,10 +3,12 @@ package ec2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	"github.com/cloudquery/cq-provider-aws/client"
 
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
@@ -144,6 +146,16 @@ func fetchEc2EbsSnapshots(ctx context.Context, meta schema.ClientMeta, parent *s
 	}
 	return nil
 }
+
+func isSnapshotNotFoundError(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr); apiErr.ErrorCode() == "InvalidSnapshot.NotFound" {
+		return true
+	}
+
+	return false
+}
+
 func resolveEc2ebsSnapshotCreateVolumePermissions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	r := resource.Item.(types.Snapshot)
 	cl := meta.(*client.Client)
@@ -156,6 +168,10 @@ func resolveEc2ebsSnapshotCreateVolumePermissions(ctx context.Context, meta sche
 	})
 
 	if err != nil {
+		if isSnapshotNotFoundError(err) {
+			meta.Logger().Debug("Failed extracting snapshot volume permissions. Snapshot not found", "SnapshotId", r.SnapshotId)
+			return nil
+		}
 		return diag.WrapError(err)
 	}
 

--- a/resources/services/ec2/ebs_snapshots.go
+++ b/resources/services/ec2/ebs_snapshots.go
@@ -144,7 +144,6 @@ func fetchEc2EbsSnapshots(ctx context.Context, meta schema.ClientMeta, parent *s
 	}
 	return nil
 }
-
 func resolveEc2ebsSnapshotCreateVolumePermissions(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	r := resource.Item.(types.Snapshot)
 	cl := meta.(*client.Client)


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Fixes https://github.com/cloudquery/cloudquery-issues/issues/327 (internal issue) to handle snapshot not found errors

I was not able to reproduce the error using deployed resources, so simulated it by forcing the wrong snapshot id in the code.
Also, initially I created the following Terraform file to deploy the resources, but realized it's not required as they are provisioned already when an ec2 instance is deployed:

```tf
# Required due to https://github.com/hashicorp/terraform-provider-aws/issues/12102
resource "aws_organizations_account" "example-account" {
  name  = "${var.prefix}-ebs-snapshot-example-account"
  email = "${var.prefix}-ebs-snapshot-example-email@cloudquery.io"
}

resource "aws_snapshot_create_volume_permission" "example-perm" {
  snapshot_id = aws_ebs_snapshot.example-snapshot.id
  account_id  = aws_organizations_account.example-account.id
}

resource "aws_ebs_volume" "example" {
  availability_zone = "us-east-1a"
  size              = 1
}

resource "aws_ebs_snapshot" "example-snapshot" {
  volume_id = aws_ebs_volume.example.id
}
```

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
