### PR TITLE
fix: Remove "increase max_retries" from the throttling error message

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -70,7 +70,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 					diag.WithType(diag.THROTTLE),
 					diag.WithSeverity(diag.WARNING),
 					ParseSummaryMessage(err),
-					diag.WithDetails("CloudQuery AWS provider has been throttled, increase max_retries in provider configuration."),
+					diag.WithDetails("CloudQuery AWS provider has been throttled. This is unexpected - you can open an issue on github (https://github.com/cloudquery/cq-provider-aws/issues) or contact us on discord (https://cloudquery.io/discord)"),
 				)...),
 			),
 		}


### PR DESCRIPTION
See context at https://github.com/cloudquery/cloudquery/issues/1391.

Increasing max_retries will not have a positive effect in most cases, and will likely
only exacerbate any "hanging" issues.

🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
