### PR TITLE
fix: Fix region error in `aws_backup_global_settings`

### DIFF
--- a/resources/services/backup/global_settings.go
+++ b/resources/services/backup/global_settings.go
@@ -48,9 +48,7 @@ func fetchBackupGlobalSettings(ctx context.Context, meta schema.ClientMeta, pare
 	svc := c.Services().Backup
 	input := backup.DescribeGlobalSettingsInput{}
 
-	output, err := svc.DescribeGlobalSettings(ctx, &input, func(o *backup.Options) {
-		o.Region = c.Region
-	})
+	output, err := svc.DescribeGlobalSettings(ctx, &input, func(o *backup.Options) {})
 	if err != nil {
 		if client.IgnoreAccessDeniedServiceDisabled(err) || client.IsAWSError(err, "ERROR_9601") /* "Your account is not a member of an organization" */ {
 			meta.Logger().Debug("received access denied on DescribeGlobalSettings", "err", err)


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

fixes region usage on global resource

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
