### PR TITLE
fix: Hardcoded region for Get-Caller-Identity call

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -388,10 +388,7 @@ func isAllRegions(regions []string) bool {
 
 func getAccountId(ctx context.Context, awsCfg aws.Config) (*sts.GetCallerIdentityOutput, error) {
 	svc := sts.NewFromConfig(awsCfg)
-	return svc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(o *sts.Options) {
-		o.Region = "aws-global"
-	})
-
+	return svc.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 }
 
 type AssumeRoleAPIClient interface {
@@ -525,7 +522,7 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 		if len(account.Regions) == 0 {
 			return nil, diags.Add(diag.FromError(fmt.Errorf("no enabled regions provided in config for account %s", account.AccountName), diag.USER))
 		}
-
+		awsCfg.Region = account.Regions[0]
 		output, err := getAccountId(ctx, awsCfg)
 		if err != nil {
 			return nil, diags.Add(classifyError(err, diag.INTERNAL, nil))


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
