### PR TITLE
fix: Fixed `NotFound` errors exceptions for some resources

### DIFF
--- a/resources/services/apigateway/rest_apis.go
+++ b/resources/services/apigateway/rest_apis.go
@@ -868,6 +868,9 @@ func fetchApigatewayRestApiModels(ctx context.Context, meta schema.ClientMeta, p
 			options.Region = c.Region
 		})
 		if err != nil {
+			if c.IsNotFoundError(err) {
+				return nil
+			}
 			return diag.WrapError(err)
 		}
 		res <- response.Items

--- a/resources/services/elbv2/listeners.go
+++ b/resources/services/elbv2/listeners.go
@@ -359,6 +359,9 @@ func fetchElbv2Listeners(ctx context.Context, meta schema.ClientMeta, parent *sc
 			options.Region = c.Region
 		})
 		if err != nil {
+			if c.IsNotFoundError(err) {
+				return nil
+			}
 			return diag.WrapError(err)
 		}
 		res <- response.Listeners

--- a/resources/services/kms/keys.go
+++ b/resources/services/kms/keys.go
@@ -213,6 +213,9 @@ func fetchKmsKeys(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 				options.Region = c.Region
 			})
 			if err != nil {
+				if c.IsNotFoundError(err) {
+					continue
+				}
 				return diag.WrapError(err)
 			}
 			if d.KeyMetadata != nil {

--- a/resources/services/lambda/functions.go
+++ b/resources/services/lambda/functions.go
@@ -1324,6 +1324,9 @@ func fetchLambdaFunctionVersions(ctx context.Context, meta schema.ClientMeta, pa
 	for {
 		output, err := svc.ListVersionsByFunction(ctx, &config)
 		if err != nil {
+			if meta.(*client.Client).IsNotFoundError(err) {
+				return nil
+			}
 			return diag.WrapError(err)
 		}
 		res <- output.Versions

--- a/resources/services/rds/cluster_snapshots.go
+++ b/resources/services/rds/cluster_snapshots.go
@@ -205,6 +205,9 @@ func resolveRDSClusterSnapshotAttributes(ctx context.Context, meta schema.Client
 		},
 	)
 	if err != nil {
+		if c.IsNotFoundError(err) {
+			return nil
+		}
 		return diag.WrapError(err)
 	}
 	if out.DBClusterSnapshotAttributesResult == nil {


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

adds `NotFound` errors ignore in `aws_apigateway_rest_apis` `aws_elbv2_listeners` `aws_kms_keys` `aws_lambda_functions` `aws_rds_cluster_snapshots`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
