### PR TITLE
fix: Revert "fix: Fail on access errors during initial setup (#906)"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -444,7 +444,7 @@ func configureAwsClient(ctx context.Context, logger hclog.Logger, awsConfig *Con
 	// Test out retrieving credentials
 	if _, err := awsCfg.Credentials.Retrieve(ctx); err != nil {
 		logger.Error("error retrieving credentials", "err", err)
-		return awsCfg, classifyError(fmt.Errorf(awsFailedToConfigureErrMsg, account.AccountName, err, checkEnvVariables()), diag.INTERNAL, nil, diag.WithSeverity(diag.ERROR))
+		return awsCfg, fmt.Errorf(awsFailedToConfigureErrMsg, account.AccountName, err, checkEnvVariables())
 	}
 
 	return awsCfg, err
@@ -517,7 +517,7 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 				}
 			})
 		if err != nil {
-			return nil, diags.Add(classifyError(fmt.Errorf("failed to find disabled regions for account %s. AWS Error: %w", account.AccountName, err), diag.INTERNAL, nil, diag.WithSeverity(diag.ERROR)))
+			return nil, diags.Add(classifyError(fmt.Errorf("failed to find disabled regions for account %s. AWS Error: %w", account.AccountName, err), diag.INTERNAL, nil))
 		}
 		account.Regions = filterDisabledRegions(localRegions, res.Regions)
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -93,7 +93,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 						diag.ACCESS,
 						append(opts,
 							diag.WithType(diag.ACCESS),
-							diag.WithOptionalSeverity(diag.WARNING),
+							diag.WithSeverity(diag.WARNING),
 							ParseSummaryMessage(err),
 							diag.WithDetails("Something is wrong with your credentials. Ensure you have access to the specified resource."),
 						)...),

--- a/client/errors.go
+++ b/client/errors.go
@@ -60,7 +60,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.ErrorCode() {
-		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure":
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure", "ExpiredToken":
 			return diag.Diagnostics{
 				RedactError(accounts, diag.NewBaseError(err,
 					diag.ACCESS,

--- a/client/errors.go
+++ b/client/errors.go
@@ -60,13 +60,13 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.ErrorCode() {
-		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure", "ExpiredToken":
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure":
 			return diag.Diagnostics{
 				RedactError(accounts, diag.NewBaseError(err,
 					diag.ACCESS,
 					append(opts,
 						diag.WithType(diag.ACCESS),
-						diag.WithOptionalSeverity(diag.WARNING),
+						diag.WithSeverity(diag.WARNING),
 						ParseSummaryMessage(err),
 						diag.WithDetails(errorCodeDescriptions[ae.ErrorCode()]),
 					)...),
@@ -79,7 +79,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 						diag.ACCESS,
 						append(opts,
 							diag.WithType(diag.ACCESS),
-							diag.WithOptionalSeverity(diag.WARNING),
+							diag.WithSeverity(diag.WARNING),
 							ParseSummaryMessage(err),
 							diag.WithDetails("Something is wrong with your credentials. Either the accessKeyId or secretAccessKey (or both) are wrong."),
 						)...),
@@ -106,7 +106,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 					diag.RESOLVING,
 					append(opts,
 						diag.WithType(diag.RESOLVING),
-						diag.WithOptionalSeverity(diag.IGNORE),
+						diag.WithSeverity(diag.IGNORE),
 						ParseSummaryMessage(err),
 						diag.WithDetails("The action is invalid for the service."),
 					)...),
@@ -133,7 +133,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 				diag.THROTTLE,
 				append(opts,
 					diag.WithType(diag.THROTTLE),
-					diag.WithOptionalSeverity(diag.WARNING),
+					diag.WithSeverity(diag.WARNING),
 					ParseSummaryMessage(err),
 					diag.WithDetails("CloudQuery AWS provider has been throttled. This is unexpected - you can open an issue on github (https://github.com/cloudquery/cq-provider-aws/issues) or contact us on discord (https://cloudquery.io/discord)"),
 				)...),


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Reverts https://github.com/cloudquery/cq-provider-aws/pull/906 as it caused some errors to show up as warning

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
