### PR TITLE
fix: Not Supported region added to error classifier

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -139,7 +139,6 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 				),
 			}
 		}
-
 	}
 	if IsErrorThrottle(err) {
 		return diag.Diagnostics{

--- a/client/errors.go
+++ b/client/errors.go
@@ -112,6 +112,19 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 					)...),
 				),
 			}
+		case "UnsupportedOperation":
+			if strings.Contains(ae.ErrorMessage(), "The functionality you requested is not available in this region.") {
+				return diag.Diagnostics{
+					RedactError(accounts, diag.NewBaseError(err,
+						diag.RESOLVING,
+						append(opts,
+							diag.WithType(diag.RESOLVING),
+							diag.WithSeverity(diag.IGNORE),
+							ParseSummaryMessage(err),
+							diag.WithDetails("The action is not available in selected region"))...),
+					),
+				}
+			}
 		}
 		if ae.ErrorMessage() == ssoInvalidOrExpired {
 			return diag.Diagnostics{
@@ -126,6 +139,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 				),
 			}
 		}
+
 	}
 	if IsErrorThrottle(err) {
 		return diag.Diagnostics{


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Some ec2 resources does not allows some operations and return error like: `operation error EC2: DescribeCustomerGateways, https response error StatusCode: 400, RequestID:xxxxxxxxxxxxxxxxxxxxxxxxx, api error UnsupportedOperation: The functionality you requested is not available in this region.`
The pr adds this kind of errors to classifier that ignores them.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
