### PR TITLE
fix: Added FailedResourceAccessException to error classifier

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -60,7 +60,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []Account, opts .
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.ErrorCode() {
-		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure", "ExpiredToken":
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure", "ExpiredToken", "FailedResourceAccessException":
 			return diag.Diagnostics{
 				RedactError(accounts, diag.NewBaseError(err,
 					diag.ACCESS,


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary
adds FailedResourceAccessException code to error classifier
errors like below will be classified as access errors:
```
applicationautoscaling.policies: failed to resolve table "aws_applicationautoscaling_policies": error at github.com/cloudquery/cq-provider-aws/resources/services/applicationautoscaling.fetchApplicationautoscalingPolicies[policies.go:118] operation error Application Auto Scaling: DescribeScalingPolicies, https response error StatusCode: 400, RequestID:xxxxxxxxxxxxxxxxxxxxx, FailedResourceAccessException: Unable to assume IAM role to retrieve alarms for scaling policy (Detail: Unable to assume IAM role: arn:aws:iam::xxxxxxxxxxxx:role/xxxxxxxxxxxxx)
````

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
