### PR TITLE
fix: Change from IgnoreAccessDeniedServiceDisabled to IgnoreCommonErrors

### DIFF
--- a/resources/services/accessanalyzer/analyzers.go
+++ b/resources/services/accessanalyzer/analyzers.go
@@ -20,7 +20,7 @@ func Analyzers() *schema.Table {
 		Description:  "Contains information about the analyzer",
 		Resolver:     fetchAccessAnalyzerAnalyzers,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("access-analyzer"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/apigateway/vpc_links.go
+++ b/resources/services/apigateway/vpc_links.go
@@ -17,7 +17,7 @@ func ApigatewayVpcLinks() *schema.Table {
 		Description:  "An API Gateway VPC link for a RestApi to access resources in an Amazon Virtual Private Cloud (VPC).",
 		Resolver:     fetchApigatewayVpcLinks,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("apigateway"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/apigatewayv2/apis.go
+++ b/resources/services/apigatewayv2/apis.go
@@ -23,7 +23,7 @@ func Apigatewayv2Apis() *schema.Table {
 		Description:  "Represents an API.",
 		Resolver:     fetchApigatewayv2Apis,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("apigateway"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/apigatewayv2/vpc_links.go
+++ b/resources/services/apigatewayv2/vpc_links.go
@@ -17,7 +17,7 @@ func Apigatewayv2VpcLinks() *schema.Table {
 		Description:  "Represents a VPC link.",
 		Resolver:     fetchApigatewayv2VpcLinks,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("apigateway"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/athena/data_catalogs.go
+++ b/resources/services/athena/data_catalogs.go
@@ -22,7 +22,7 @@ func DataCatalogs() *schema.Table {
 		Description:  "Contains information about a data catalog in an Amazon Web Services account",
 		Resolver:     fetchAthenaDataCatalogs,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("athena"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/athena/work_groups.go
+++ b/resources/services/athena/work_groups.go
@@ -20,7 +20,7 @@ func WorkGroups() *schema.Table {
 		Description:  "A workgroup, which contains a name, description, creation time, state, and other configuration, listed under WorkGroup$Configuration",
 		Resolver:     fetchAthenaWorkGroups,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("athena"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/autoscaling/configurations.go
+++ b/resources/services/autoscaling/configurations.go
@@ -17,7 +17,7 @@ func AutoscalingLaunchConfigurations() *schema.Table {
 		Description:  "Describes a launch configuration.",
 		Resolver:     fetchAutoscalingLaunchConfigurations,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("autoscaling"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/autoscaling/groups.go
+++ b/resources/services/autoscaling/groups.go
@@ -26,7 +26,7 @@ func AutoscalingGroups() *schema.Table {
 		Description:  "Describes an Auto Scaling group.",
 		Resolver:     fetchAutoscalingGroups,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("autoscaling"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/autoscaling/scheduled_actions.go
+++ b/resources/services/autoscaling/scheduled_actions.go
@@ -17,7 +17,7 @@ func AutoscalingScheduledActions() *schema.Table {
 		Description:  "Describes a scheduled scaling action.",
 		Resolver:     fetchAutoscalingScheduledActions,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("autoscaling"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/backup/global_settings.go
+++ b/resources/services/backup/global_settings.go
@@ -15,7 +15,7 @@ func GlobalSettings() *schema.Table {
 		Name:         "aws_backup_global_settings",
 		Resolver:     fetchBackupGlobalSettings,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("backup"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id"}},
 		Global:       true,

--- a/resources/services/backup/plans.go
+++ b/resources/services/backup/plans.go
@@ -18,7 +18,7 @@ func Plans() *schema.Table {
 		Description:  "Contains metadata about a backup plan.",
 		Resolver:     fetchBackupPlans,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("backup"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/backup/region_settings.go
+++ b/resources/services/backup/region_settings.go
@@ -15,7 +15,7 @@ func RegionSettings() *schema.Table {
 		Name:         "aws_backup_region_settings",
 		Resolver:     fetchBackupRegionSettings,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("backup"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region"}},
 		Columns: []schema.Column{

--- a/resources/services/cloudformation/stacks.go
+++ b/resources/services/cloudformation/stacks.go
@@ -23,7 +23,7 @@ func Stacks() *schema.Table {
 		Description:  "The Stack data type.",
 		Resolver:     fetchCloudformationStacks,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("cloudformation"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{

--- a/resources/services/cloudfront/cache_policies.go
+++ b/resources/services/cloudfront/cache_policies.go
@@ -17,7 +17,7 @@ func CloudfrontCachePolicies() *schema.Table {
 		Description:  "Contains a cache policy.",
 		Resolver:     fetchCloudfrontCachePolicies,
 		Multiplex:    client.AccountMultiplex,
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/cloudfront/distributions.go
+++ b/resources/services/cloudfront/distributions.go
@@ -17,7 +17,7 @@ func CloudfrontDistributions() *schema.Table {
 		Description:  "A summary of the information about a CloudFront distribution.",
 		Resolver:     fetchCloudfrontDistributions,
 		Multiplex:    client.AccountMultiplex,
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/codepipeline/pipelines.go
+++ b/resources/services/codepipeline/pipelines.go
@@ -24,7 +24,7 @@ func Pipelines() *schema.Table {
 		Description:  "Represents the output of a GetPipeline action.",
 		Resolver:     fetchCodepipelinePipelines,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("codepipeline"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/codepipeline/webhooks.go
+++ b/resources/services/codepipeline/webhooks.go
@@ -18,7 +18,7 @@ func Webhooks() *schema.Table {
 		Description:  "The detail returned for each webhook after listing webhooks, such as the webhook URL, the webhook name, and the webhook ARN.",
 		Resolver:     fetchCodepipelineWebhooks,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("codepipeline"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/elasticbeanstalk/application_versions.go
+++ b/resources/services/elasticbeanstalk/application_versions.go
@@ -17,7 +17,7 @@ func ApplicationVersions() *schema.Table {
 		Description:  "Describes the properties of an application version.",
 		Resolver:     fetchElasticbeanstalkApplicationVersions,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("elasticbeanstalk"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/elasticsearch/domains.go
+++ b/resources/services/elasticsearch/domains.go
@@ -16,7 +16,7 @@ func ElasticsearchDomains() *schema.Table {
 		Description:  "The current status of an Elasticsearch domain.",
 		Resolver:     fetchElasticsearchDomains,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("es"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/elbv2/load_balancers.go
+++ b/resources/services/elbv2/load_balancers.go
@@ -36,7 +36,7 @@ func Elbv2LoadBalancers() *schema.Table {
 		Description:  "Information about a load balancer.",
 		Resolver:     fetchElbv2LoadBalancers,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("elasticloadbalancing"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/lambda/layers.go
+++ b/resources/services/lambda/layers.go
@@ -22,7 +22,7 @@ func LambdaLayers() *schema.Table {
 		Description:  "Details about an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). ",
 		Resolver:     fetchLambdaLayers,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("lambda"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/redshift/clusters.go
+++ b/resources/services/redshift/clusters.go
@@ -18,7 +18,7 @@ func RedshiftClusters() *schema.Table {
 		Description:  "Describes a cluster.",
 		Resolver:     fetchRedshiftClusters,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("redshift"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/redshift/event_subscriptions.go
+++ b/resources/services/redshift/event_subscriptions.go
@@ -18,7 +18,7 @@ func EventSubscriptions() *schema.Table {
 		Description:  "Describes event subscriptions.",
 		Resolver:     fetchRedshiftEventSubscriptions,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("redshift"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/redshift/subnet_groups.go
+++ b/resources/services/redshift/subnet_groups.go
@@ -18,7 +18,7 @@ func RedshiftSubnetGroups() *schema.Table {
 		Description:  "Describes a subnet group.",
 		Resolver:     fetchRedshiftSubnetGroups,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("redshift"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/route53/hosted_zones.go
+++ b/resources/services/route53/hosted_zones.go
@@ -26,7 +26,7 @@ func Route53HostedZones() *schema.Table {
 		Description:  "A complex type that contains general information about the hosted zone.",
 		Resolver:     fetchRoute53HostedZones,
 		Multiplex:    client.AccountMultiplex,
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/sagemaker/notebook_instances.go
+++ b/resources/services/sagemaker/notebook_instances.go
@@ -23,7 +23,7 @@ func SagemakerNotebookInstances() *schema.Table {
 		Description:  "Provides summary information for an Amazon SageMaker notebook instance.",
 		Resolver:     fetchSagemakerNotebookInstances,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("api.sagemaker"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/waf/web_acls.go
+++ b/resources/services/waf/web_acls.go
@@ -23,7 +23,7 @@ func WafWebAcls() *schema.Table {
 		Description:  "This is AWS WAF Classic documentation",
 		Resolver:     fetchWafWebAcls,
 		Multiplex:    client.AccountMultiplex,
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/wafregional/rate_based_rules.go
+++ b/resources/services/wafregional/rate_based_rules.go
@@ -18,7 +18,7 @@ func RateBasedRules() *schema.Table {
 		Description:  "This is AWS WAF Classic documentation",
 		Resolver:     fetchWafregionalRateBasedRules,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/wafregional/rule_groups.go
+++ b/resources/services/wafregional/rule_groups.go
@@ -18,7 +18,7 @@ func RuleGroups() *schema.Table {
 		Description:  "This is AWS WAF Classic documentation",
 		Resolver:     fetchWafregionalRuleGroups,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/wafregional/rules.go
+++ b/resources/services/wafregional/rules.go
@@ -18,7 +18,7 @@ func Rules() *schema.Table {
 		Description:  "This is AWS WAF Classic documentation",
 		Resolver:     fetchWafregionalRules,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/wafregional/web_acls.go
+++ b/resources/services/wafregional/web_acls.go
@@ -18,7 +18,7 @@ func WebAcls() *schema.Table {
 		Description:  "This is AWS WAF Classic documentation",
 		Resolver:     fetchWafregionalWebAcls,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/wafv2/ipsets.go
+++ b/resources/services/wafv2/ipsets.go
@@ -19,7 +19,7 @@ func Ipsets() *schema.Table {
 		Description:  "Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation",
 		Resolver:     fetchWafv2Ipsets,
 		Multiplex:    client.ServiceAccountRegionScopeMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionScopeFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/wafv2/regex_pattern_sets.go
+++ b/resources/services/wafv2/regex_pattern_sets.go
@@ -18,7 +18,7 @@ func RegexPatternSets() *schema.Table {
 		Description:  "Contains one or more regular expressions",
 		Resolver:     fetchWafv2RegexPatternSets,
 		Multiplex:    client.ServiceAccountRegionScopeMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionScopeFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/wafv2/rule_groups.go
+++ b/resources/services/wafv2/rule_groups.go
@@ -19,7 +19,7 @@ func Wafv2RuleGroups() *schema.Table {
 		Description:  "A rule group defines a collection of rules to inspect and control web requests that you can use in a WebACL",
 		Resolver:     fetchWafv2RuleGroups,
 		Multiplex:    client.ServiceAccountRegionScopeMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionScopeFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/wafv2/web_acls.go
+++ b/resources/services/wafv2/web_acls.go
@@ -24,7 +24,7 @@ func Wafv2WebAcls() *schema.Table {
 		Description:  "A Web ACL defines a collection of rules to use to inspect and control web requests",
 		Resolver:     fetchWafv2WebAcls,
 		Multiplex:    client.ServiceAccountRegionScopeMultiplexer("waf-regional"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionScopeFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/workspaces/directories.go
+++ b/resources/services/workspaces/directories.go
@@ -18,7 +18,7 @@ func Directories() *schema.Table {
 		Description:  "Describes a directory that is used with Amazon WorkSpaces.",
 		Resolver:     fetchWorkspacesDirectories,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("workspaces"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{

--- a/resources/services/workspaces/workspaces.go
+++ b/resources/services/workspaces/workspaces.go
@@ -19,7 +19,7 @@ func Workspaces() *schema.Table {
 		Description:  "Describes a WorkSpace.",
 		Resolver:     fetchWorkspacesWorkspaces,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("workspaces"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"id"}},
 		Columns: []schema.Column{

--- a/resources/services/xray/encryption_config.go
+++ b/resources/services/xray/encryption_config.go
@@ -16,7 +16,7 @@ func EncryptionConfigs() *schema.Table {
 		Description:  "A configuration document that specifies encryption configuration settings.",
 		Resolver:     fetchXrayEncryptionConfigs,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("xray"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "region"}},
 		Columns: []schema.Column{

--- a/resources/services/xray/groups.go
+++ b/resources/services/xray/groups.go
@@ -18,7 +18,7 @@ func Groups() *schema.Table {
 		Description:  "Details for a group.",
 		Resolver:     fetchXrayGroups,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("xray"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{

--- a/resources/services/xray/sampling_rules.go
+++ b/resources/services/xray/sampling_rules.go
@@ -18,7 +18,7 @@ func SamplingRules() *schema.Table {
 		Description:  "A SamplingRule.",
 		Resolver:     fetchXraySamplingRules,
 		Multiplex:    client.ServiceAccountRegionMultiplexer("xray"),
-		IgnoreError:  client.IgnoreAccessDeniedServiceDisabled,
+		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

When we use `IgnoreAccessDeniedServiceDisabled` we have to handle certain errors like 404/ Resource not found errors in the resolvers. By changing to IgnoreCommonErrors we get that at the table level without any extra code.

I am not 100% sure this is valid or if there are cases when we do NOT want to ignore 404s

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
