### PR TITLE
fix: Redshift Panic

### DIFF
--- a/resources/services/redshift/clusters.go
+++ b/resources/services/redshift/clusters.go
@@ -880,6 +880,9 @@ func fetchRedshiftClusterDeferredMaintenanceWindows(ctx context.Context, meta sc
 }
 func fetchRedshiftClusterEndpointVpcEndpoints(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 	cluster := parent.Item.(types.Cluster)
+	if cluster.Endpoint == nil {
+		return nil
+	}
 	res <- cluster.Endpoint.VpcEndpoints
 	return nil
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

`Cluster.Endpoint` can be nil. need to check prior to accessing nested attributes


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
