### PR TITLE
fix: Explicitly Ignore EC2 Classic EIPs

### DIFF
--- a/resources/services/ec2/eips.go
+++ b/resources/services/ec2/eips.go
@@ -131,7 +131,6 @@ func fetchEc2Eips(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 		return diag.WrapError(err)
 	}
 	res <- output.Addresses
-
 	return nil
 }
 func resolveEc2eipTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {

--- a/resources/services/ec2/eips.go
+++ b/resources/services/ec2/eips.go
@@ -120,7 +120,6 @@ func Ec2Eips() *schema.Table {
 //                                               Table Resolver Functions
 // ====================================================================================================================
 func fetchEc2Eips(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
-	var diags diag.Diagnostics
 	c := meta.(*client.Client)
 	svc := c.Services().EC2
 	output, err := svc.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{
@@ -133,7 +132,7 @@ func fetchEc2Eips(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 	}
 	res <- output.Addresses
 
-	return diags
+	return nil
 }
 func resolveEc2eipTags(ctx context.Context, meta schema.ClientMeta, resource *schema.Resource, c schema.Column) error {
 	r := resource.Item.(types.Address)

--- a/resources/services/ec2/eips.go
+++ b/resources/services/ec2/eips.go
@@ -130,10 +130,12 @@ func fetchEc2Eips(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 		return diag.WrapError(err)
 	}
 	for _, address := range output.Addresses {
-		if address.AllocationId != nil {
-			res <- address
+		if address.AllocationId == nil {
+			diags = diags.Add(diag.FromError(fmt.Errorf("eip for EC2 Classic is not supported"), diag.RESOLVING, diag.WithSeverity(diag.WARNING)))
+			continue
 		}
-		diags = diags.Add(diag.FromError(fmt.Errorf("eip for EC2 Classic is not supported"), diag.RESOLVING, diag.WithSeverity(diag.WARNING)))
+		res <- address
+
 	}
 
 	return diags

--- a/resources/services/ec2/eips.go
+++ b/resources/services/ec2/eips.go
@@ -135,7 +135,6 @@ func fetchEc2Eips(ctx context.Context, meta schema.ClientMeta, parent *schema.Re
 			continue
 		}
 		res <- address
-
 	}
 
 	return diags


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

EC2 Classic is being turned off in August. It was deprecated last year and was disabled by default 10 years ago. CQ has never fully supported EC2 classic and we will not be adding support for it now


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
