### PR TITLE
fix: Classify credential errors as USER type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -446,7 +446,12 @@ func configureAwsClient(ctx context.Context, logger hclog.Logger, awsConfig *Con
 	// Test out retrieving credentials
 	if _, err := awsCfg.Credentials.Retrieve(ctx); err != nil {
 		logger.Error("error retrieving credentials", "err", err)
-		return awsCfg, err
+		return awsCfg, diag.FromError(
+			err,
+			diag.USER,
+			diag.WithSummary("No credentials available"),
+			diag.WithDetails("Coundn't find any credentials in environment variables or configuration files."),
+		)
 	}
 
 	return awsCfg, err


### PR DESCRIPTION
Prevents sending

    : failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds:
    GetMetadata, request canceled, context deadline exceeded

error handling