### PR TITLE
fix: Public ip is used as pk in ec2_eips

### DIFF
--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -127,7 +127,7 @@ func Provider() *provider.Provider {
 			"ec2.ebs_snapshots":                     ec2.Ec2EbsSnapshots(),
 			"ec2.ebs_volumes":                       ec2.Ec2EbsVolumes(),
 			"ec2.egress_only_internet_gateways":     ec2.EgressOnlyInternetGateways(),
-			"ec2.eips":                              ec2.Ec2Eips(),
+			"ec2.eips":                              ec2.Eips(),
 			"ec2.hosts":                             ec2.Hosts(),
 			"ec2.flow_logs":                         ec2.Ec2FlowLogs(),
 			"ec2.images":                            ec2.Ec2Images(),

--- a/resources/services/ec2/eips_mock_test.go
+++ b/resources/services/ec2/eips_mock_test.go
@@ -37,5 +37,5 @@ func buildEc2Eips(t *testing.T, ctrl *gomock.Controller) client.Services {
 }
 
 func TestEc2Eips(t *testing.T) {
-	client.AwsMockTestHelper(t, Ec2Eips(), buildEc2Eips, client.TestOptions{})
+	client.AwsMockTestHelper(t, Eips(), buildEc2Eips, client.TestOptions{})
 }

--- a/resources/services/ec2/gen.hcl
+++ b/resources/services/ec2/gen.hcl
@@ -52,8 +52,8 @@ resource "aws" "ec2" "egress_only_internet_gateways" {
   }
 
   userDefinedColumn "arn" {
-    type        = "string"
-    description = "The Amazon Resource Name (ARN) for the egress-only internet gateway."
+    type              = "string"
+    description       = "The Amazon Resource Name (ARN) for the egress-only internet gateway."
     generate_resolver = false
   }
 
@@ -130,14 +130,14 @@ resource "aws" "ec2" "network_interfaces" {
   }
 
   userDefinedColumn "arn" {
-    type        = "string"
-    description = "The Amazon Resource Name (ARN) for the egress-only internet gateway."
+    type              = "string"
+    description       = "The Amazon Resource Name (ARN) for the egress-only internet gateway."
     generate_resolver = false
   }
 
   userDefinedColumn "tags" {
-    type        = "json"
-    description = "Any tags assigned to the network interface."
+    type              = "json"
+    description       = "Any tags assigned to the network interface."
     generate_resolver = false
   }
 
@@ -211,9 +211,84 @@ resource "aws" "ec2" "hosts" {
   }
 
   userDefinedColumn "arn" {
-    type        = "string"
-    description = "The Amazon Resource Name (ARN) for the dedicated host."
+    type              = "string"
+    description       = "The Amazon Resource Name (ARN) for the dedicated host."
     generate_resolver = false
   }
 
+}
+
+
+resource "aws" "ec2" "eips" {
+  path = "github.com/aws/aws-sdk-go-v2/service/ec2/types.Address"
+  ignoreError "IgnoreAccessDenied" {
+    path = "github.com/cloudquery/cq-provider-aws/client.IgnoreCommonErrors"
+  }
+  deleteFilter "AccountRegionFilter" {
+    path = "github.com/cloudquery/cq-provider-aws/client.DeleteAccountRegionFilter"
+  }
+  multiplex "AwsAccountRegion" {
+    path   = "github.com/cloudquery/cq-provider-aws/client.ServiceAccountRegionMultiplexer"
+    params = ["ec2"]
+  }
+
+
+  options {
+    primary_keys = ["account_id", "public_ip"]
+  }
+
+  userDefinedColumn "account_id" {
+    description = "The AWS Account ID of the resource."
+    type        = "string"
+    resolver "resolveAWSAccount" {
+      path = "github.com/cloudquery/cq-provider-aws/client.ResolveAWSAccount"
+    }
+  }
+  userDefinedColumn "region" {
+    type        = "string"
+    description = "The AWS Region of the resource."
+    resolver "resolveAWSRegion" {
+      path = "github.com/cloudquery/cq-provider-aws/client.ResolveAWSRegion"
+    }
+  }
+
+  column "private_ip_address" {
+    type = "inet"
+    resolver "ColumnResolver" {
+      path   = "github.com/cloudquery/cq-provider-sdk/provider/schema.IPAddressResolver"
+      params = ["PrivateIpAddress"]
+    }
+  }
+
+  column "public_ip" {
+    type = "inet"
+    resolver "ColumnResolver" {
+      path   = "github.com/cloudquery/cq-provider-sdk/provider/schema.IPAddressResolver"
+      params = ["PublicIp"]
+    }
+  }
+
+  column "customer_owned_ip" {
+    type = "inet"
+    resolver "ColumnResolver" {
+      path   = "github.com/cloudquery/cq-provider-sdk/provider/schema.IPAddressResolver"
+      params = ["CustomerOwnedIp"]
+    }
+  }
+
+
+  column "carrier_ip" {
+    type = "inet"
+    resolver "ColumnResolver" {
+      path   = "github.com/cloudquery/cq-provider-sdk/provider/schema.IPAddressResolver"
+      params = ["CarrierIp"]
+    }
+  }
+
+
+  column "tags" {
+    type              = "json"
+    generate_resolver = true
+    description       = "Any tags assigned to the Elastic IP address."
+  }
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

fixes error when alloction_id is `null` because of old resources that left from ec2 classic

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
