### PR TITLE
fix: Change PK in aws_ec2_vpc_endpoint_services from (account_id, id)

### DIFF
--- a/resources/services/ec2/vpc_endpoint_services.go
+++ b/resources/services/ec2/vpc_endpoint_services.go
@@ -19,7 +19,7 @@ func Ec2VpcEndpointServices() *schema.Table {
 		Multiplex:    client.ServiceAccountRegionMultiplexer("ec2"),
 		IgnoreError:  client.IgnoreCommonErrors,
 		DeleteFilter: client.DeleteAccountRegionFilter,
-		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"account_id", "id"}},
+		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"arn"}},
 		Columns: []schema.Column{
 			{
 				Name:        "account_id",


### PR DESCRIPTION
Usually we use arn as PK (so that even if its the same id in different regions, we wont get duplicate-pk).

We can reopen the issue if it persists even with this fix.

closes: https://github.com/cloudquery/cloudquery-issues/issues/411

🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
