### PR TITLE
fix: Diagnostic blocking Use of Orgs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run: build
 # Run a fetch command
 .PHONY: fetch
 fetch:
-	CQ_PROVIDER_DEBUG=1 CQ_REATTACH_PROVIDERS=.cq_reattach cloudquery fetch --dsn "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable" -v --fail-on-error
+	CQ_PROVIDER_DEBUG=1 CQ_REATTACH_PROVIDERS=.cq_reattach cloudquery fetch --dsn "postgres://postgres:pass@localhost:5432/postgres?sslmode=disable" -v
 
 # Generate mocks for mock/unit testing 
 .PHONY: generate-mocks

--- a/client/client.go
+++ b/client/client.go
@@ -451,6 +451,7 @@ func configureAwsClient(ctx context.Context, logger hclog.Logger, awsConfig *Con
 			diag.USER,
 			diag.WithSummary("No credentials available"),
 			diag.WithDetails("Couldn't find any credentials in environment variables or configuration files."),
+			diag.WithSeverity(diag.WARNING),
 		)
 	}
 
@@ -522,6 +523,7 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 				if accountErr == nil {
 					principal = *output.Arn
 				}
+
 				diags = diags.Add(diag.FromError(err, diag.ACCESS, diag.WithDetails("ensure that %s has access to be able perform `sts:AssumeRole` on %s ", principal, account.RoleARN), diag.WithSeverity(diag.WARNING)))
 				continue
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

change diag to be a warning.


```
Fetch Diagnostics:

Type: User Severity: Warning
        Summary: No credentials available: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: **, api error AccessDenied: User: arn:aws:sts::ACCOUNT_ID:role:assumed-role/SSO-ROLE is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::ACCOUNT_ID:role/ROLE
        Detail: Couldn't find any credentials in environment variables or configuration files.
Type: User Severity: Warning
        Summary: No credentials available: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: **, api error AccessDenied: User: arn:aws:sts::ACCOUNT_ID:role:assumed-role/SSO-ROLE is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::ACCOUNT_ID:role/ROLE
        Detail: Couldn't find any credentials in environment variables or configuration files.

Provider aws fetch summary: ✓ Total Resources fetched: 4129
```

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
