### PR TITLE
fix(tests): Update Lightsail terraform for Integration testing of Instances

### DIFF
--- a/terraform/lightsail/modules/test/buckets.tf
+++ b/terraform/lightsail/modules/test/buckets.tf
@@ -1,4 +1,4 @@
 resource "awslightsail_bucket" "awslightsail_bucket" {
-  name      = "${var.prefix}-lightsail-bucket"
+  name      = "${lower(var.prefix)}-lightsail-bucket"
   bundle_id = "small_1_0"
 }

--- a/terraform/lightsail/modules/test/containers.tf
+++ b/terraform/lightsail/modules/test/containers.tf
@@ -1,10 +1,10 @@
 # create a new Lightsail container service
 resource "awslightsail_container_service" "awslightsail_container_service" {
-  name        = "${var.prefix}-container-service"
+  name        = "${lower(var.prefix)}-container-service"
   power       = "nano"
   scale       = 1
   is_disabled = false
-  tags = {
+  tags        = {
     foo1 = "bar1"
     foo2 = ""
   }

--- a/terraform/lightsail/modules/test/disk.tf
+++ b/terraform/lightsail/modules/test/disk.tf
@@ -1,5 +1,9 @@
 resource "awslightsail_disk" "awslightsail_disk" {
   name              = "${var.prefix}_awslightsail_disk"
   size_in_gb        = 8
-  availability_zone = "us-east-1a"
+  availability_zone = "us-east-1b"
+  tags              = {
+    foo1 = "bar1"
+    foo2 = ""
+  }
 }

--- a/terraform/lightsail/modules/test/instances.tf
+++ b/terraform/lightsail/modules/test/instances.tf
@@ -1,10 +1,14 @@
-# Create a new GitLab Lightsail Instance
+# Create a new Lightsail Instance
 resource "aws_lightsail_instance" "aws_lightsail_instance" {
-  name              = "${var.prefix}-lightsaleinstance"
+  name              = "${var.prefix}-lightsailinstance"
   availability_zone = "us-east-1b"
   blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_2_0"
   key_pair_name     = aws_lightsail_key_pair.aws_lightsail_key_pair.name
+  tags              = {
+    foo1 = "bar1"
+    foo2 = ""
+  }
 }
 
 resource "aws_lightsail_static_ip_attachment" "test" {
@@ -12,8 +16,13 @@ resource "aws_lightsail_static_ip_attachment" "test" {
   instance_name  = aws_lightsail_instance.aws_lightsail_instance.id
 }
 
-
 resource "awslightsail_lb_attachment" "test" {
   load_balancer_name = awslightsail_lb.awslightsail_lb.name
   instance_name      = aws_lightsail_instance.aws_lightsail_instance.name
+}
+
+resource "awslightsail_disk_attachment" "test" {
+  disk_name     = awslightsail_disk.awslightsail_disk.name
+  instance_name = aws_lightsail_instance.aws_lightsail_instance.name
+  disk_path     = "/dev/xvdf"
 }

--- a/terraform/lightsail/modules/test/lb.tf
+++ b/terraform/lightsail/modules/test/lb.tf
@@ -1,5 +1,5 @@
 resource "awslightsail_lb" "awslightsail_lb" {
-  name              = "${var.prefix}_load_ballancer"
+  name              = "${var.prefix}_load_balancer"
   health_check_path = "/"
   instance_port     = "80"
 }


### PR DESCRIPTION
- attach a disk to an instance, a requirement for integration testing Lightsail Instances with disks attached. The disk and instance must also be in the same region and AZ
- certain resource names must be lowercase; we should therefore convert the prefix to lowercase for those cases
- fix some typos