### PR TITLE
fix: Classify ExpiredTokenException as ACCESS err

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -75,7 +75,7 @@ func classifyError(err error, fallbackType diag.Type, accounts []string, opts ..
 	var ae smithy.APIError
 	if errors.As(err, &ae) {
 		switch ae.ErrorCode() {
-		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure", "ExpiredToken", "FailedResourceAccessException":
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "AuthorizationError", "OptInRequired", "SubscriptionRequiredException", "InvalidClientTokenId", "AuthFailure", "ExpiredToken", "ExpiredTokenException", "FailedResourceAccessException":
 			return diag.Diagnostics{
 				RedactError(accounts, diag.NewBaseError(err,
 					diag.ACCESS,


### PR DESCRIPTION
This should affect errors like:

lambda.functions: failed to resolve table "aws_lambda_function_concurrency_configs": error at github.com/cloudquery/cq-provider-aws/resources/services/lambda.fetchLambdaFunctionConcurrencyConfigs[functions.go:1365] operation error Lambda: ListProvisionedConcurrencyConfigs, https response error StatusCode: 403, RequestID: xxxx, api error ExpiredTokenException: The security token included in the request is expired