### PR TITLE
fix: Ignore SimpleQueueService.NonExistentQueue

### DIFF
--- a/client/helpers.go
+++ b/client/helpers.go
@@ -66,6 +66,7 @@ var (
 
 var notFoundErrorSubstrings = []string{
 	"InvalidAMIID.Unavailable",
+	"NonExistentQueue",
 	"NoSuch",
 	"NotFound",
 	"ResourceNotFoundException",


### PR DESCRIPTION
Should fix 
```
sqs.queues: failed to resolve table "aws_sqs_queues": error at github.com/cloudquery/cq-provider-aws/resources/services/sqs.fetchSQSQueues[queues.go:224] operation error SQS: GetQueueAttributes, https response error StatusCode: 400, RequestID: xxxx, api error AWS.SimpleQueueService.NonExistentQueue: The specified queue does not exist for this wsdl version.

```