### PR TITLE
fix(build): Fix name of script in Github workflow

### DIFF
--- a/.github/workflows/check_generated_code_drift.yml
+++ b/.github/workflows/check_generated_code_drift.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Fail if new cq-gen config file is missing //check-for-changes
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         run: |
-          ./scripts/check-new-files-have-check-for-changes.sh
+          ./scripts/check-new-files-have-check-for-changes-flag.sh
       - name: Run go generate on changed service directories
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         run: |


### PR DESCRIPTION
Typo introduced in https://github.com/cloudquery/cq-provider-aws/pull/1401