### PR TITLE
chore(tests): Disable decorder on resource files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,7 @@ issues:
     - path: resources(\\|\/).*\.go
       linters:
         - dupl
+        - decorder
     # Exclude some linters from running on services files.
     - path: services\.go
       linters:


### PR DESCRIPTION
Decorder is a bit too strict on our cq-gen generated files, and is forcing us to place all structs at the top of the file, even though this is not the current behavior of cq-gen. It seems unnecessarily strict for generated files, let's disable it for now.

Relates to https://github.com/cloudquery/.github/issues/266